### PR TITLE
fix memory management issues

### DIFF
--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -521,7 +521,7 @@ void OPL3::Reset(int emulator, unsigned long PCM_RATE)
     regBD.clear();
 
     #ifndef ADLMIDI_HW_OPL
-    cardsOP2.resize(NumCards, AdlMIDI_CPtr<OPLChipBase>());
+    cardsOP2.resize(NumCards, AdlMIDI_SPtr<OPLChipBase>());
     #endif
 
     NumChannels = NumCards * 23;


### PR DESCRIPTION
AddressSanitizer raises an issue in latest versions.

```==6765==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x603000001900```

1. This is because instances of **OPLChipBase** are kept under the smart pointer **AdlMIDI_CPtr**, which invokes **free** in the destructor, not **delete**.

2. Moreover, there is a vector of **AdlMIDI_CPtr**. It suffers from the same problem in C++98 as **vector<auto_ptr<>>**. Contents are destroyed when the vector grows because of copy.

I took a few actions to solve this.

1. I put OPLChipBase instances in shared pointers. Because **std::shared_ptr** is forbidden, I implement **AdlMIDI_SPtr** in replacement.

2. I protect **AdlMIDI_CPtr** against copies with private visibility.