### PR TITLE
fix SPtr implementation mistake

### DIFF
--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -216,6 +216,8 @@ public:
 
     AdlMIDI_SPtr &operator=(const AdlMIDI_SPtr &other)
     {
+        if(this == &other)
+            return *this;
         reset();
         m_p = other.m_p;
         m_counter = other.m_counter;


### PR DESCRIPTION
It's a kind of moment when you hover your old code and realize your error.
After some years of implementing stl-like stuff I still can never get a shared_ptr right on first try.

It's a pretty inconsequential mistake bur maybe it will save someone some future hair pulling.
Fixes self-assignment.