### PR TITLE
flexible emulator selection API

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -162,9 +162,35 @@ enum ADL_Emulator
     ADLMIDI_EMU_end
 };
 
+/* Returns chip emulator */
+extern int adl_chipEmulator(struct ADL_MIDIPlayer *device);
+
 /* Switch the emulation core */
 extern int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulator);
 
+enum ADL_EmulatorProfileFlag
+{
+    ADLMIDI_EMUPROFILE_FAST          = 1 << 0,
+    ADLMIDI_EMUPROFILE_FASTEST       = 1 << 1,
+    ADLMIDI_EMUPROFILE_ACCURATE      = 1 << 2,
+    ADLMIDI_EMUPROFILE_MOST_ACCURATE = 1 << 3,
+    ADLMIDI_EMUPROFILE_BALANCED      = 1 << 4,
+};
+
+struct ADL_EmulatorCharacteristics
+{
+    const char *name;
+    int profile;
+};
+
+/* Returns the number of emulators built into the library. */
+extern int adl_getNumEmulators();
+
+/* Returns the characteristics of the emulator. */
+extern const struct ADL_EmulatorCharacteristics *adl_describeEmulator(int emulator);
+
+/* Returns an emulation core matching all given profile flags. */
+extern int adl_matchEmulator(int profile);
 
 typedef struct {
     ADL_UInt16 major;

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -44,6 +44,8 @@ static const ADLMIDI_AudioFormat adl_DefaultAudioFormat =
     2 * sizeof(int16_t),
 };
 
+extern ADL_EmulatorCharacteristics globalEmulatorChs[ADLMIDI_EMU_end];
+
 /*---------------------------EXPORTS---------------------------*/
 
 ADLMIDI_EXPORT struct ADL_MIDIPlayer *adl_init(long sample_rate)
@@ -349,6 +351,17 @@ ADLMIDI_EXPORT const char *adl_chipEmulatorName(struct ADL_MIDIPlayer *device)
     return "Unknown";
 }
 
+ADLMIDI_EXPORT int adl_chipEmulator(struct ADL_MIDIPlayer *device)
+{
+    if(device)
+    {
+        MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+        if(play)
+            return play->m_setup.emulator;
+    }
+    return -1;
+}
+
 ADLMIDI_EXPORT int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulator)
 {
     if(device)
@@ -361,6 +374,31 @@ ADLMIDI_EXPORT int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulato
             return 0;
         }
         play->setErrorString("OPN2 MIDI: Unknown emulation core!");
+    }
+    return -1;
+}
+
+ADLMIDI_EXPORT int adl_getNumEmulators()
+{
+    return ADLMIDI_EMU_end;
+}
+
+ADLMIDI_EXPORT const ADL_EmulatorCharacteristics *adl_describeEmulator(int emulator)
+{
+    if (emulator >= ADLMIDI_EMU_end)
+        return NULL;
+    ADL_EmulatorCharacteristics *chs = &globalEmulatorChs[emulator];
+    return chs->name ? chs : NULL;
+}
+
+ADLMIDI_EXPORT int adl_matchEmulator(int profile)
+{
+    if(profile == 0)
+        return (ADL_Emulator)0;  // the default
+    for(unsigned i = 0; i < ADLMIDI_EMU_end; ++i) {
+        ADL_EmulatorCharacteristics *chs = &globalEmulatorChs[i];
+        if (chs->name && (chs->profile & profile) == profile)
+            return i;
     }
     return -1;
 }

--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -42,6 +42,26 @@ static const unsigned OPLBase = 0x388;
 #   endif
 #endif
 
+ADL_EmulatorCharacteristics globalEmulatorChs[ADLMIDI_EMU_end] =
+{
+#ifndef ADLMIDI_DISABLE_NUKED_EMULATOR
+    { NukedOPL3::staticEmulatorName,
+      ADLMIDI_EMUPROFILE_ACCURATE|ADLMIDI_EMUPROFILE_MOST_ACCURATE },
+    { NukedOPL3v174::staticEmulatorName,
+      ADLMIDI_EMUPROFILE_ACCURATE },
+#else
+    { NULL, 0 },
+    { NULL, 0 },
+#endif
+
+#ifndef ADLMIDI_DISABLE_DOSBOX_EMULATOR
+    { DosBoxOPL3::staticEmulatorName,
+      ADLMIDI_EMUPROFILE_FAST|ADLMIDI_EMUPROFILE_FASTEST|ADLMIDI_EMUPROFILE_BALANCED },
+#else
+    { NULL, 0 },
+#endif
+};
+
 #ifdef DISABLE_EMBEDDED_BANKS
 /*
     Dummy data which replaces adldata.cpp banks database

--- a/src/chips/dosbox_opl3.cpp
+++ b/src/chips/dosbox_opl3.cpp
@@ -106,7 +106,9 @@ int DosBoxOPL3::generateAndMix32(int32_t *output, size_t frames)
     return (int)frames;
 }
 
+const char *const DosBoxOPL3::staticEmulatorName = "DosBox 0.74 OPL3";
+
 const char *DosBoxOPL3::emulatorName()
 {
-    return "DosBox 0.74 OPL3";
+    return staticEmulatorName;
 }

--- a/src/chips/dosbox_opl3.h
+++ b/src/chips/dosbox_opl3.h
@@ -20,6 +20,8 @@ public:
     virtual int generate32(int32_t *output, size_t frames) override;
     virtual int generateAndMix32(int32_t *output, size_t frames) override;
     virtual const char *emulatorName() override;
+
+    static const char *const staticEmulatorName;
 };
 
 #endif // DOSBOX_OPL3_H

--- a/src/chips/nuked_opl3.cpp
+++ b/src/chips/nuked_opl3.cpp
@@ -87,7 +87,9 @@ int NukedOPL3::generateAndMix32(int32_t *output, size_t frames)
     return (int)frames;
 }
 
+const char *const NukedOPL3::staticEmulatorName = "Nuked OPL3 (v 1.8)";
+
 const char *NukedOPL3::emulatorName()
 {
-    return "Nuked OPL3 (v 1.8)";
+    return staticEmulatorName;
 }

--- a/src/chips/nuked_opl3.h
+++ b/src/chips/nuked_opl3.h
@@ -20,6 +20,8 @@ public:
     virtual int generate32(int32_t *output, size_t frames) override;
     virtual int generateAndMix32(int32_t *output, size_t frames) override;
     virtual const char *emulatorName() override;
+
+    static const char *const staticEmulatorName;
 };
 
 #endif // NUKED_OPL3_H

--- a/src/chips/nuked_opl3_v174.cpp
+++ b/src/chips/nuked_opl3_v174.cpp
@@ -87,7 +87,9 @@ int NukedOPL3v174::generateAndMix32(int32_t *output, size_t frames)
     return (int)frames;
 }
 
+const char *const NukedOPL3v174::staticEmulatorName = "Nuked OPL3 (v 1.7.4)";
+
 const char *NukedOPL3v174::emulatorName()
 {
-    return "Nuked OPL3 (v 1.7.4)";
+    return staticEmulatorName;
 }

--- a/src/chips/nuked_opl3_v174.h
+++ b/src/chips/nuked_opl3_v174.h
@@ -20,6 +20,8 @@ public:
     virtual int generate32(int32_t *output, size_t frames) override;
     virtual int generateAndMix32(int32_t *output, size_t frames) override;
     virtual const char *emulatorName() override;
+
+    static const char *const staticEmulatorName;
 };
 
 #endif // NUKED_OPL3174_H


### PR DESCRIPTION
Not being entirely happy with the state of emulator-related APIs, so I imagined an extension of it, and I submit it to your comments.

**Before** I would enumerate the emulators by creating a fake player, invoke `switchEmulator` for 0 to count until a -1 return. I would avoid relying on hardcoded values of `ADL_Emulator`. In the future, it's imaginable that Nuked 1.7 will be entirely superseded and removed.

**Now** This is an API proposal which could be very well used without any enum `ADL_Emulator`.
It has a query ability for emulator and their characteristics.

Enter the concept of **profile**. You can use a combination of profile flags to find a matching emulator. See adlmidi.h
Exactly one emulator should match **FASTEST**, idem for **MOST_ACCURATE**. Note these two flags don't necessarily imply **FAST** and **ACCURATE** respectively.

**Rationale**: I just want to present normal users who don't care about detail, a generic setting of speed/quality compromise choice.