### PR TITLE
explicit link against the library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 3.2)
 project (libADLMIDI)
 
 #===========================================================================================
@@ -264,6 +264,13 @@ endif()
 if(NOT libADLMIDI_STATIC AND NOT libADLMIDI_SHARED)
     message(FATAL_ERROR "Both static and shared libADLMIDI builds are disabled!
 You must enable at least one of them!")
+endif()
+
+add_library(ADLMIDI INTERFACE)
+if(libADLMIDI_SHARED)
+  target_link_libraries(ADLMIDI INTERFACE ADLMIDI_shared)
+else()
+  target_link_libraries(ADLMIDI INTERFACE ADLMIDI_static)
 endif()
 
 if(WITH_MIDIPLAY)


### PR DESCRIPTION
The build links the programs against library "ADLMIDI".

But it's not a target defined in the cmake file. It will resolve as the link flag -lADLMIDI.
As a result, the build may pick the system library instead of the built one.
It will also not handle the dependency right. adlmidiplay does not rebuild if there is a change in the library.

This is extremely confusing.
I fix it by creating the interface target ADLMIDI. (and bump the cmake version number for support)