### PR TITLE
wopl robustness fix

### DIFF
--- a/src/wopl/wopl_file.c
+++ b/src/wopl/wopl_file.c
@@ -133,6 +133,7 @@ static void WOPL_parseInstrument(WOPLInstrument *ins, uint8_t *cursor, uint16_t 
 {
     int l;
     strncpy(ins->inst_name, (const char*)cursor, 32);
+    ins->inst_name[32] = '\0';
     ins->note_offset1 = toSint16BE(cursor + 32);
     ins->note_offset2 = toSint16BE(cursor + 34);
     ins->midi_velocity_offset = (int8_t)cursor[36];
@@ -284,6 +285,7 @@ WOPLFile *WOPL_LoadBankFromMem(void *mem, size_t length, int *error)
                     return NULL;
                 }
                 strncpy(bankslots[i][j].bank_name, (const char*)cursor, 32);
+                bankslots[i][j].bank_name[32] = '\0';
                 bankslots[i][j].bank_midi_lsb = cursor[32];
                 bankslots[i][j].bank_midi_msb = cursor[33];
                 GO_FORWARD(34);


### PR DESCRIPTION
The loader has a byte intended to hold the null terminator of the name.
`snprintf` does not write this byte if the name takes the maximum size (32).

In the bank loading case it's benign because the memory is initialized with zero.
Not in `WOPL_LoadInstFromMem` where the user provides the structure.
Anyway I correct both cases.

---
In my variant of code I will just remove this byte to save the padding space. I am used to handle strings in binary structs, I will not make use of this safety.