### PR TITLE
wopl API: give names to struct and enum types

### DIFF
--- a/src/wopl/wopl_file.h
+++ b/src/wopl/wopl_file.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 /* Global OPL flags */
-typedef enum
+typedef enum WOPLFileFlags
 {
     /* Enable Deep-Tremolo flag */
     WOPL_FLAG_DEEP_TREMOLO = 0x01,
@@ -42,7 +42,7 @@ typedef enum
 } WOPLFileFlags;
 
 /* Volume scaling model implemented in the libADLMIDI */
-typedef enum
+typedef enum WOPL_VolumeModel
 {
     WOPL_VM_Generic = 0,
     WOPL_VM_Native,
@@ -51,7 +51,7 @@ typedef enum
     WOPL_VM_Win9x
 } WOPL_VolumeModel;
 
-typedef enum
+typedef enum WOPL_InstrumentFlags
 {
     /* Is two-operator single-voice instrument (no flags) */
     WOPL_Ins_2op        = 0x00,
@@ -69,7 +69,7 @@ typedef enum
     WOPL_Ins_ALL_MASK   = 0x07
 } WOPL_InstrumentFlags;
 
-typedef enum
+typedef enum WOPL_RythmMode
 {
     /* RythmMode: BassDrum */
     WOPL_RM_BassDrum  = 0x08,
@@ -84,7 +84,7 @@ typedef enum
 } WOPL_RythmMode;
 
 /* Error codes */
-typedef enum
+typedef enum WOPL_ErrorCodes
 {
     WOPL_ERR_OK = 0,
     /* Magic number is not maching */
@@ -108,7 +108,7 @@ typedef enum
 #define WOPL_OP_MODULATOR2  3
 
 /* OPL3 Oerators data  */
-typedef struct
+typedef struct WOPLOperator
 {
     /* AM/Vib/Env/Ksr/FMult characteristics */
     uint8_t avekf_20;
@@ -123,7 +123,7 @@ typedef struct
 } WOPLOperator;
 
 /* Instrument entry */
-typedef struct
+typedef struct WOPLInstrument
 {
     /* Title of the instrument */
     char    inst_name[34];
@@ -152,7 +152,7 @@ typedef struct
 } WOPLInstrument;
 
 /* Bank entry */
-typedef struct
+typedef struct WOPLBank
 {
     /* Name of bank */
     char    bank_name[33];
@@ -165,7 +165,7 @@ typedef struct
 } WOPLBank;
 
 /* Instrument data file */
-typedef struct
+typedef struct WOPIFile
 {
     /* Version of instrument file */
     uint16_t        version;
@@ -176,7 +176,7 @@ typedef struct
 } WOPIFile;
 
 /* Bank data file */
-typedef struct
+typedef struct WOPLFile
 {
     /* Version of bank file */
     uint16_t version;


### PR DESCRIPTION
Puts names on the types, instead of only typedefs.
Otherwise I can't forward declare the types of this API.
eg. `struct WOPLInstrument;`. It's not possible to write this.