### PR TITLE
meaningful handling of pitch bend sensitivity

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -2358,8 +2358,14 @@ void MIDIplay::SetRPN(unsigned MidCh, unsigned value, bool MSB)
     switch(addr + nrpn * 0x10000 + MSB * 0x20000)
     {
     case 0x0000 + 0*0x10000 + 1*0x20000: // Pitch-bender sensitivity
-        Ch[MidCh].bendsense = value / 8192.0;
+    {
+        if (MSB)
+            Ch[MidCh].bendsense_msb = value;
+        else
+            Ch[MidCh].bendsense_lsb = value;
+        Ch[MidCh].updateBendSensitivity();
         break;
+    }
     case 0x0108 + 1*0x10000 + 1*0x20000: // Vibrato speed
         if(value == 64)      Ch[MidCh].vibspeed = 1.0;
         else if(value < 100) Ch[MidCh].vibspeed = 1.0 / (1.6e-2 * (value ? value : 1));

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -599,6 +599,7 @@ public:
         uint8_t panning, vibrato, sustain;
         char ____padding[6];
         double  bend, bendsense;
+        int bendsense_lsb, bendsense_msb;
         double  vibpos, vibspeed, vibdepth;
         int64_t vibdelay;
         uint8_t lastlrpn, lastmrpn;
@@ -791,7 +792,9 @@ public:
         void resetAllControllers()
         {
             bend = 0.0;
-            bendsense = 2 / 8192.0;
+            bendsense_msb = 2;
+            bendsense_lsb = 0;
+            updateBendSensitivity();
             volume  = 100;
             expression = 127;
             sustain = 0;
@@ -802,6 +805,11 @@ public:
             panning = OPL_PANNING_BOTH;
             portamento = 0;
             brightness = 127;
+        }
+        void updateBendSensitivity()
+        {
+            int cent = bendsense_msb * 100 + bendsense_lsb;
+            bendsense = cent * (0.01 / 8192.0);
         }
         MIDIchannel()
         {


### PR DESCRIPTION
This ADLMIDI code handles the pitchbend sensitivity RPN setting wrong.
It defines `bendsense` according to the RPN MSB, but the `SetRPN` will allow it to take a value from either LSB or MSB, which is an error.

Moreover:

I have found this [definition](http://www.lim.di.unimi.it/IEEE/MIDI/SOT1.HTM#Pitch) of this RPN.
MSB is supposed to be semitones, and LSB in cents.
I add a piece of code which adds consideration for LSB in the computation.

**But**

I've had issues with bizarre sounding pitchbend every now and then, and I try to find why. It's still the case with this patch applied.
For example [this one](http://www.rppmf.com/dream_theater/2005-octavarium/08-dream_theater_2005-octavarium.mid) gets very happy with pitchbend at around 12:15. Timidity is able to get the tone right, but not ADLMIDI.