### PR TITLE
c++98 support for bank map

### DIFF
--- a/src/adlmidi_bankmap.h
+++ b/src/adlmidi_bankmap.h
@@ -25,9 +25,8 @@
 #define ADLMIDI_BANKMAP_H
 
 #include <list>
-#include <memory>
 #include <utility>
-#include <cstdint>
+#include <stdint.h>
 
 #include "adlmidi_ptr.hpp"
 
@@ -79,15 +78,15 @@ public:
     class iterator
     {
     public:
-        iterator() {}
+        iterator();
         value_type &operator*() const { return slot->value; }
         value_type *operator->() const { return &slot->value; }
         iterator &operator++();
         bool operator==(const iterator &o) const;
         bool operator!=(const iterator &o) const;
     private:
-        Slot **buckets = nullptr, *slot = nullptr;
-        size_t index = 0;
+        Slot **buckets, *slot;
+        size_t index;
         iterator(Slot **buckets, Slot *slot, size_t index);
 #ifdef _MSC_VER
         template<class _T>
@@ -99,14 +98,15 @@ public:
 
 private:
     struct Slot {
-        Slot *next = nullptr, *prev = nullptr;
+        Slot *next, *prev;
         value_type value;
+        Slot() : next(NULL), prev(NULL) {}
     };
-    std::unique_ptr<Slot *[]> m_buckets;
-    std::list<std::unique_ptr<Slot[]>> m_allocations;
-    Slot *m_freeslots = nullptr;
-    size_t m_size = 0;
-    size_t m_capacity = 0;
+    AdlMIDI_SPtrArray<Slot *> m_buckets;
+    std::list< AdlMIDI_SPtrArray<Slot> > m_allocations;
+    Slot *m_freeslots;
+    size_t m_size;
+    size_t m_capacity;
     static size_t hash(key_type key);
     Slot *allocate_slot();
     Slot *ensure_allocate_slot();

--- a/src/adlmidi_bankmap.tcc
+++ b/src/adlmidi_bankmap.tcc
@@ -57,7 +57,7 @@ void BasicBankMap<T>::reserve(size_t capacity)
     m_capacity += need;
 
     for(size_t i = need; i-- > 0;)
-        free_slot(&slots.get()[i]);
+        free_slot(&slots[i]);
 }
 
 template <class T>
@@ -65,7 +65,7 @@ typename BasicBankMap<T>::iterator
 BasicBankMap<T>::begin() const
 {
     iterator it(m_buckets.get(), NULL, 0);
-    while(it.index < hash_buckets && !(it.slot = m_buckets.get()[it.index]))
+    while(it.index < hash_buckets && !(it.slot = m_buckets[it.index]))
         ++it.index;
     return it;
 }
@@ -176,12 +176,12 @@ template <class T>
 void BasicBankMap<T>::clear()
 {
     for(size_t i = 0; i < hash_buckets; ++i) {
-        Slot *slot = m_buckets.get()[i];
+        Slot *slot = m_buckets[i];
         while (Slot *cur = slot) {
             slot = slot->next;
             free_slot(cur);
         }
-        m_buckets.get()[i] = NULL;
+        m_buckets[i] = NULL;
     }
     m_size = 0;
 }
@@ -231,7 +231,7 @@ template <class T>
 typename BasicBankMap<T>::Slot *
 BasicBankMap<T>::bucket_find(size_t index, key_type key)
 {
-    Slot *slot = m_buckets.get()[index];
+    Slot *slot = m_buckets[index];
     while(slot && slot->value.first != key)
         slot = slot->next;
     return slot;
@@ -241,11 +241,11 @@ template <class T>
 void BasicBankMap<T>::bucket_add(size_t index, Slot *slot)
 {
     assert(slot);
-    Slot *next = m_buckets.get()[index];
+    Slot *next = m_buckets[index];
     if(next)
         next->prev = slot;
     slot->next = next;
-    m_buckets.get()[index] = slot;
+    m_buckets[index] = slot;
 }
 
 template <class T>
@@ -255,7 +255,7 @@ void BasicBankMap<T>::bucket_remove(size_t index, Slot *slot)
     Slot *prev = slot->prev;
     Slot *next = slot->next;
     if(!prev)
-        m_buckets.get()[index] = next;
+        m_buckets[index] = next;
     else
         prev->next = next;
     if(next)

--- a/src/adlmidi_ptr.hpp
+++ b/src/adlmidi_ptr.hpp
@@ -23,6 +23,9 @@
 
 #ifndef ADLMIDI_PTR_HPP_THING
 #define ADLMIDI_PTR_HPP_THING
+
+#include <stddef.h>
+
 /*
     Smart pointer for C heaps, created with malloc() call.
     FAQ: Why not std::shared_ptr? Because of Android NDK now doesn't supports it
@@ -177,16 +180,13 @@ public:
             if(m_p && --*m_counter == 0) {
                 DELETER del;
                 del(m_p);
-            }
-            m_p = p;
-            if(!p) {
-                if(m_counter) {
+                if(!p) {
                     delete m_counter;
                     m_counter = NULL;
                 }
             }
-            else
-            {
+            m_p = p;
+            if(p) {
                 if(!m_counter)
                     m_counter = new size_t;
                 *m_counter = 1;


### PR DESCRIPTION
C++98 bank map implemented using custom shared pointers.
The shared pointer receives a deleter argument, which is to define in order to invoke `delete[]` on the pointer which is wrapped.
Also changed the more minor things here and there.