### PR TITLE
attempt to rework 4op count computation

### DIFF
--- a/src/adlmidi_private.cpp
+++ b/src/adlmidi_private.cpp
@@ -63,7 +63,6 @@ int adlRefreshNumCards(ADL_MIDIPlayer *device)
 
     unsigned NumFourOps = ((n_fourop[0] == 0) && (n_fourop[1] == 0)) ? 0
         : (n_fourop[0] >= (n_total[0] * 7) / 8) ? play->m_setup.NumCards * 6
-        : (n_fourop[0] < (n_total[0] * 1) / 8) ? 0
         : (play->m_setup.NumCards == 1 ? 1 : play->m_setup.NumCards * 4);
 
     play->opl.NumFourOps = play->m_setup.NumFourOps = NumFourOps;


### PR DESCRIPTION
#92 

I would like to have a discussion on computation of 4op channel count.
It's a code I don't like, for the hazardous way to statically fix the channel count, and also I find it to be nonsensical in several ways.
I know that this thing was Joel's code originally.

1. The dynamic banks counts the blank instruments, which makes total count erroneous for the final estimation. It's a thing I have attempted to fix.

2. There is a modulo 128 applied to the total I find no explanation for, and which I would think is better to remove.

3. I understand the computation of `NumFourOps` like this:
- If there's no 4-ops => 0
- The 4-ops use more than 7/8 of the bank => 6
- The 4-ops use less than 1/8 of the bank => **0** (**can't have any 4-ops in this case??????**)
- Otherwise if it's single chip 1, else 4

The error message following makes no sense. If there is >= 15/16 instruments with 4-op, `NumFourOps` will not be 0, so how can the condition ever be entered?
Beside, ADLMIDI never checks the return value of this function, so this error condition is completely meaningless in context.