### PR TITLE
bank storage inside dynamic map

### DIFF
--- a/src/adlmidi_bankmap.h
+++ b/src/adlmidi_bankmap.h
@@ -27,6 +27,7 @@
 #include <list>
 #include <utility>
 #include <stdint.h>
+#include <stddef.h>
 
 #include "adlmidi_ptr.hpp"
 

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1001,7 +1001,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
             //Let XG SFX1/SFX2 bank will have LSB==1 (128...255 range in WOPN file)
             //Let XG Percussion bank will use (0...127 range in WOPN file)
             bank = (uint16_t)midiins + ((bank == 0x7E00) ? 128 : 0); // MIDI instrument defines the patch
-            midiins = opl.dynamic_percussion_offset + note; // Percussion instrument
+            midiins = note; // Percussion instrument
             isXgPercussion = true;
             isPercussion = false;
         }
@@ -1010,42 +1010,35 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     if(isPercussion)
     {
         bank = (uint16_t)midiins; // MIDI instrument defines the patch
-        midiins = opl.dynamic_percussion_offset + note; // Percussion instrument
+        midiins = note; // Percussion instrument
     }
+    if(isPercussion || isXgPercussion)
+        bank += OPL3::PercussionTag;
 
     //Set bank bank
-    if(bank > 0)
+    const OPL3::Bank *bnk = NULL;
+    if((bank & ~(uint16_t)OPL3::PercussionTag) > 0)
     {
-        if(isPercussion || isXgPercussion)
+        OPL3::BankMap::iterator b = opl.dynamic_banks.find(bank);
+        if(b != opl.dynamic_banks.end())
+            bnk = &b->second;
+
+        if(!bnk && hooks.onDebugMessage)
         {
-            OPL3::BankMap::iterator b = opl.dynamic_percussion_banks.find(bank);
-            if(b != opl.dynamic_percussion_banks.end())
-                midiins += b->second * 128;
-            else
-            if(hooks.onDebugMessage)
-            {
-                if(!caugh_missing_banks_melodic.count(bank))
-                {
-                    hooks.onDebugMessage(hooks.onDebugMessage_userData, "[%i] Playing missing percussion MIDI bank %i (patch %i)", channel, bank, midiins);
-                    caugh_missing_banks_melodic.insert(bank);
-                }
-            }
+            std::set<uint16_t> &missing = (isPercussion || isXgPercussion) ?
+                caugh_missing_banks_percussion : caugh_missing_banks_melodic;
+            const char *text = (isPercussion || isXgPercussion) ?
+                "percussion" : "melodic";
+            if(missing.insert(bank).second)
+                hooks.onDebugMessage(hooks.onDebugMessage_userData, "[%i] Playing missing %s MIDI bank %i (patch %i)", channel, text, bank, midiins);
         }
-        else
-        {
-            OPL3::BankMap::iterator b = opl.dynamic_melodic_banks.find(bank);
-            if(b != opl.dynamic_melodic_banks.end())
-                midiins += b->second * 128;
-            else
-            if(hooks.onDebugMessage)
-            {
-                if(!caugh_missing_banks_percussion.count(bank))
-                {
-                    hooks.onDebugMessage(hooks.onDebugMessage_userData, "[%i] Playing missing melodic MIDI bank %i (patch %i)", channel, bank, midiins);
-                    caugh_missing_banks_percussion.insert(bank);
-                }
-            }
-        }
+    }
+    //Or fall back to first bank
+    if(!bnk)
+    {
+        OPL3::BankMap::iterator b = opl.dynamic_banks.find((bank & OPL3::PercussionTag));
+        if(b != opl.dynamic_banks.end())
+            bnk = &b->second;
     }
 
     /*
@@ -1057,8 +1050,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     //if(midiins == 56) vol = vol*6/10; // HACK
     //int meta = banks[opl.AdlBank][midiins];
 
-    size_t              meta   = opl.GetAdlMetaNumber(midiins);
-    adlinsdata2        ains   = opl.GetAdlMetaIns(meta);
+    const adlinsdata2 &ains = bnk ? bnk->ins[midiins] : OPL3::emptyInstrument;
     int16_t tone = note;
 
     if(!isPercussion && !isXgPercussion && (bank > 0)) // For non-zero banks
@@ -1067,16 +1059,11 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
         {
             if(hooks.onDebugMessage)
             {
-                if(!caugh_missing_instruments.count(static_cast<uint8_t>(midiins)))
-                {
+                if(caugh_missing_instruments.insert(static_cast<uint8_t>(midiins)).second)
                     hooks.onDebugMessage(hooks.onDebugMessage_userData, "[%i] Caugh a blank instrument %i (offset %i) in the MIDI bank %u", channel, Ch[channel].patch, midiins, bank);
-                    caugh_missing_instruments.insert(static_cast<uint8_t>(midiins));
-                }
             }
             bank = 0;
             midiins = midiChan.patch;
-            meta    = opl.GetAdlMetaNumber(midiins);
-            ains    = opl.GetAdlMetaIns(meta);
         }
     }
 
@@ -1114,11 +1101,9 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
 
     if(hooks.onDebugMessage)
     {
-        if(!caugh_missing_instruments.count(static_cast<uint8_t>(midiins)) && (ains.flags & adlinsdata::Flag_NoSound))
-        {
+        if((ains.flags & adlinsdata::Flag_NoSound) &&
+           caugh_missing_instruments.insert(static_cast<uint8_t>(midiins)).second)
             hooks.onDebugMessage(hooks.onDebugMessage_userData, "[%i] Playing missing instrument %i", channel, midiins);
-            caugh_missing_instruments.insert(static_cast<uint8_t>(midiins));
-        }
     }
 
     // Allocate AdLib channel (the physical sound channel for the note)
@@ -1211,7 +1196,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     ir.first->vibrato = midiChan.noteAftertouch[note];
     ir.first->tone    = tone;
     ir.first->midiins = midiins;
-    ir.first->insmeta = meta;
+    ir.first->ains = &ains;
     ir.first->chip_channels_count = 0;
 
     for(unsigned ccount = 0; ccount < MIDIchannel::NoteInfo::MaxNumPhysChans; ++ccount)
@@ -1449,8 +1434,7 @@ void MIDIplay::NoteUpdate(uint16_t MidCh,
     const int16_t tone    = info.tone;
     const uint8_t vol     = info.vol;
     const int midiins     = info.midiins;
-    const size_t  insmeta = info.insmeta;
-    const adlinsdata2 ains = opl.GetAdlMetaIns(insmeta);
+    const adlinsdata2 &ains = *info.ains;
     AdlChannel::Location my_loc;
     my_loc.MidCh = MidCh;
     my_loc.note  = info.note;
@@ -2606,7 +2590,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::DoNote(int note)
     OPL3 *opl = P->opl;
     if(P->adl_ins_list.empty()) FindAdlList();
     const unsigned meta = P->adl_ins_list[P->ins_idx];
-    const adlinsdata2 ains = opl->GetAdlMetaIns(meta);
+    const adlinsdata2 ains(adlins[meta]);
 
     int tone = (P->cur_gm & 128) ? (P->cur_gm & 127) : (note + 50);
     if(ains.tone)
@@ -2680,7 +2664,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::NextAdl(int offset)
     for(unsigned a = 0, n = P->adl_ins_list.size(); a < n; ++a)
     {
         const unsigned i = P->adl_ins_list[a];
-        const adlinsdata2 ains = opl->GetAdlMetaIns(i);
+        const adlinsdata2 ains(adlins[i]);
 
         char ToneIndication[8] = "   ";
         if(ains.tone)

--- a/src/adlmidi_private.cpp
+++ b/src/adlmidi_private.cpp
@@ -34,16 +34,21 @@ int adlRefreshNumCards(ADL_MIDIPlayer *device)
     if(play->opl.AdlBank == ~0u)
     {
         //For custom bank
-        for(size_t a = 0; a < play->opl.dynamic_metainstruments.size(); ++a)
+        OPL3::BankMap::iterator it = play->opl.dynamic_banks.begin();
+        OPL3::BankMap::iterator end = play->opl.dynamic_banks.end();
+        for(; it != end; ++it)
         {
-            adlinsdata2 &ins = play->opl.dynamic_metainstruments[a];
-            if(ins.flags & adlinsdata::Flag_NoSound)
-                continue;
-
-            size_t div = (a >= play->opl.dynamic_percussion_offset) ? 1 : 0;
-            ++n_total[div];
-            if(ins.flags & adlinsdata::Flag_Real4op)
-                ++n_fourop[div];
+            uint16_t bank = it->first;
+            unsigned div = (bank & OPL3::PercussionTag) ? 1 : 0;
+            for(unsigned i = 0; i < 128; ++i)
+            {
+                adlinsdata2 &ins = it->second.ins[i];
+                if(ins.flags & adlinsdata::Flag_NoSound)
+                    continue;
+                if((ins.adl[0] != ins.adl[1]) && ((ins.flags & adlinsdata::Flag_Pseudo4op) == 0))
+                    ++n_fourop[div];
+                ++n_total[div];
+            }
         }
     }
     else

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -220,22 +220,19 @@ private:
     std::vector<uint8_t>    regBD;
 
     friend int adlRefreshNumCards(ADL_MIDIPlayer *device);
-    //! Meta information about every instrument
-    std::vector<adlinsdata2>    dynamic_metainstruments; // Replaces adlins[] when CMF file
-    //! Raw instrument data ready to be sent to the chip
-    std::vector<adldata>        dynamic_instruments;     // Replaces adl[]    when CMF file
-    size_t                      dynamic_percussion_offset;
-
-    typedef BasicBankMap<size_t> BankMap;
-    BankMap dynamic_melodic_banks;
-    BankMap dynamic_percussion_banks;
+public:
+    struct Bank
+    {
+        adlinsdata2 ins[128];
+    };
+    typedef BasicBankMap<Bank> BankMap;
+private:
+    BankMap dynamic_banks;
     AdlBankSetup dynamic_bank_setup;
-    const unsigned  DynamicInstrumentTag /* = 0x8000u*/,
-                    DynamicMetaInstrumentTag /* = 0x4000000u*/;
-    adlinsdata2         GetAdlMetaIns(size_t n);
-    size_t              GetAdlMetaNumber(size_t midiins);
 public:
     void    setEmbeddedBank(unsigned int bank);
+    static const adlinsdata2 emptyInstrument;
+    enum { PercussionTag = 1 << 15 };
 
     //! Total number of running concurrent emulated chips
     unsigned int NumCards;
@@ -530,10 +527,10 @@ public:
             // Tone selected on noteon:
             int16_t tone;
             char ____padding2[4];
-            // Patch selected on noteon; index to banks[AdlBank][]
+            // Patch selected on noteon; index to bank.ins[]
             size_t  midiins;
-            // Index to physical adlib data structure, adlins[]
-            size_t  insmeta;
+            // Patch selected
+            const adlinsdata2 *ains;
             enum
             {
                 MaxNumPhysChans = 2,


### PR DESCRIPTION
This is the storage of structure `adlinsdata2` inside the dynamic map.

Now, all bank storage used by the MIDI player happens is made to happen inside this map.
For embedded banks, when `setEmbeddedBank` is called, it will copy the internal bank into entry 0:0 of the map.

The bank identifier is the 16bit integer PMMMMMMM 0LLLLLLL. (Percussive, MSB, LSB)
A bit operation identifies the bank as melodic or percussion. It's the bit value `OPL3::PercussionTag`.

When the MIDI player won't find a bank, il will fall back to 0:0.

I find it not bad as it is now, but I think later I'll be interested to keep a counter of the number of actual (non-blank) instruments contained in the banks slots.