### PR TITLE
dynamic instrument API

### DIFF
--- a/src/adldata.hh
+++ b/src/adldata.hh
@@ -104,4 +104,14 @@ inline adlinsdata2::adlinsdata2(const adlinsdata &d)
     adl[1] = ::adl[d.adlno2];
 }
 
+/**
+ * @brief Convert external instrument to internal instrument
+ */
+void cvt_ADLI_to_FMIns(adlinsdata2 &dst, const struct ADL_Instrument &src);
+
+/**
+ * @brief Convert internal instrument to external instrument
+ */
+void cvt_FMIns_to_ADLI(struct ADL_Instrument &dst, const adlinsdata2 &src);
+
 #endif //ADLDATA_H

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -143,6 +143,142 @@ ADLMIDI_EXPORT const char *const *adl_getBankNames()
     return banknames;
 }
 
+ADLMIDI_EXPORT int adl_reserveBanks(ADL_MIDIPlayer *device, unsigned banks)
+{
+    if(!device)
+        return -1;
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    OPL3::BankMap &map = play->opl.dynamic_banks;
+    map.reserve(banks);
+    return (int)map.capacity();
+}
+
+ADLMIDI_EXPORT int adl_getBank(ADL_MIDIPlayer *device, const ADL_BankId *idp, int flags, ADL_Bank *bank)
+{
+    if(!device || !idp || !bank)
+        return -1;
+
+    ADL_BankId id = *idp;
+    if(id.lsb > 127 || id.msb > 127 || id.percussive > 1)
+        return -1;
+    unsigned idnumber = (id.msb << 8) | id.lsb | (id.percussive ? OPL3::PercussionTag : 0);
+
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    OPL3::BankMap &map = play->opl.dynamic_banks;
+
+    OPL3::BankMap::iterator it;
+    if(!(flags & ADLMIDI_Bank_Create))
+    {
+        it = map.find(idnumber);
+        if(it == map.end())
+            return -1;
+    }
+    else
+    {
+        std::pair<uint16_t, OPL3::Bank> value;
+        value.first = idnumber;
+        memset(&value.second, 0, sizeof(value.second));
+        for (unsigned i = 0; i < 128; ++i)
+            value.second.ins[i].flags = adlinsdata::Flag_NoSound;
+
+        std::pair<OPL3::BankMap::iterator, bool> ir;
+        if(flags & ADLMIDI_Bank_CreateRt)
+        {
+            ir = map.insert(value, OPL3::BankMap::do_not_expand_t());
+            if(ir.first == map.end())
+                return -1;
+        }
+        else
+            ir = map.insert(value);
+        it = ir.first;
+    }
+
+    it.to_ptrs(bank->pointer);
+    return 0;
+}
+
+ADLMIDI_EXPORT int adl_getBankId(ADL_MIDIPlayer *device, const ADL_Bank *bank, ADL_BankId *id)
+{
+    if(!device || !bank)
+        return -1;
+
+    OPL3::BankMap::iterator it = OPL3::BankMap::iterator::from_ptrs(bank->pointer);
+    unsigned idnumber = it->first;
+    id->msb = (idnumber >> 8) & 127;
+    id->lsb = idnumber & 127;
+    id->percussive = (idnumber & OPL3::PercussionTag) ? 1 : 0;
+    return 0;
+}
+
+ADLMIDI_EXPORT int adl_removeBank(ADL_MIDIPlayer *device, ADL_Bank *bank)
+{
+    if(!device || !bank)
+        return -1;
+
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    OPL3::BankMap &map = play->opl.dynamic_banks;
+    OPL3::BankMap::iterator it = OPL3::BankMap::iterator::from_ptrs(bank->pointer);
+    size_t size = map.size();
+    map.erase(it);
+    return (map.size() != size) ? 0 : -1;
+}
+
+ADLMIDI_EXPORT int adl_getFirstBank(ADL_MIDIPlayer *device, ADL_Bank *bank)
+{
+    if(!device)
+        return -1;
+
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    OPL3::BankMap &map = play->opl.dynamic_banks;
+
+    OPL3::BankMap::iterator it = map.begin();
+    if(it == map.end())
+        return -1;
+
+    it.to_ptrs(bank->pointer);
+    return 0;
+}
+
+ADLMIDI_EXPORT int adl_getNextBank(ADL_MIDIPlayer *device, ADL_Bank *bank)
+{
+    if(!device)
+        return -1;
+
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    OPL3::BankMap &map = play->opl.dynamic_banks;
+
+    OPL3::BankMap::iterator it = OPL3::BankMap::iterator::from_ptrs(bank->pointer);
+    if(++it == map.end())
+        return -1;
+
+    it.to_ptrs(bank->pointer);
+    return 0;
+}
+
+ADLMIDI_EXPORT int adl_getInstrument(ADL_MIDIPlayer *device, const ADL_Bank *bank, unsigned index, ADL_Instrument *ins)
+{
+    if(!device || !bank || index > 127 || !ins)
+        return 1;
+
+    OPL3::BankMap::iterator it = OPL3::BankMap::iterator::from_ptrs(bank->pointer);
+    cvt_FMIns_to_ADLI(*ins, it->second.ins[index]);
+    ins->version = 0;
+    return 0;
+}
+
+ADLMIDI_EXPORT int adl_setInstrument(ADL_MIDIPlayer *device, ADL_Bank *bank, unsigned index, const ADL_Instrument *ins)
+{
+    if(!device || !bank || index > 127 || !ins)
+        return 1;
+
+    if(ins->version != 0)
+        return 1;
+
+    OPL3::BankMap::iterator it = OPL3::BankMap::iterator::from_ptrs(bank->pointer);
+    cvt_ADLI_to_FMIns(it->second.ins[index], *ins);
+    return 0;
+}
+
 ADLMIDI_EXPORT int adl_setNumFourOpsChn(ADL_MIDIPlayer *device, int ops4)
 {
     if(!device)

--- a/src/adlmidi_bankmap.h
+++ b/src/adlmidi_bankmap.h
@@ -85,6 +85,8 @@ public:
         iterator &operator++();
         bool operator==(const iterator &o) const;
         bool operator!=(const iterator &o) const;
+        void to_ptrs(void *ptrs[3]);
+        static iterator from_ptrs(void *const ptrs[3]);
     private:
         Slot **buckets;
         Slot *slot;

--- a/src/adlmidi_bankmap.tcc
+++ b/src/adlmidi_bankmap.tcc
@@ -137,6 +137,25 @@ inline bool BasicBankMap<T>::iterator::operator!=(const iterator &o) const
 }
 
 template <class T>
+void BasicBankMap<T>::iterator::to_ptrs(void *ptrs[3])
+{
+    ptrs[0] = buckets;
+    ptrs[1] = slot;
+    ptrs[2] = (void *)index;
+}
+
+template <class T>
+typename BasicBankMap<T>::iterator
+BasicBankMap<T>::iterator::from_ptrs(void *const ptrs[3])
+{
+    iterator it;
+    it.buckets = (Slot **)ptrs[0];
+    it.slot = (Slot *)ptrs[1];
+    it.index = (size_t)ptrs[2];
+    return it;
+}
+
+template <class T>
 std::pair<typename BasicBankMap<T>::iterator, bool>
 BasicBankMap<T>::insert(const value_type &value)
 {

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -35,6 +35,9 @@
 #   endif
 #endif
 
+// Require declarations of unstable API for extern "C"
+#define ADLMIDI_UNSTABLE_API
+
 #ifdef _WIN32
 #define NOMINMAX
 #endif
@@ -226,7 +229,6 @@ public:
         adlinsdata2 ins[128];
     };
     typedef BasicBankMap<Bank> BankMap;
-private:
     BankMap dynamic_banks;
     AdlBankSetup dynamic_bank_setup;
 public:


### PR DESCRIPTION
#59 

This is a simple API for external access of dynamic banks.

Most operations are here, except some I will be interested to add in a moment:
- creating a bank with possibility to reuse a blank bank slot of there exists one. (to add as `ADL_BankAccessFlags`) [1]
- getting the number of banks. I don't have a lot of use for this, and this would enter in naming confusion with the unfortunately existing `adl_getBanksCount`.

To accelerate [1], I wish to keep a counter of used instruments in dynamic banks.
It would be initialized when a bank is loaded either from embedded or WOPL file source, and successively incremented or decremented by following calls of `adl_setInstrument`.