### PR TITLE
new pitchbend strategy

### DIFF
--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -504,8 +504,8 @@ public:
         //! Is note aftertouch has any non-zero value
         bool    noteAfterTouchInUse;
         char ____padding[6];
-        double bendSrc;
-        double  bend, bendsense;
+        int bend;
+        double bendsense;
         int bendsense_lsb, bendsense_msb;
         double  vibpos, vibspeed, vibdepth;
         int64_t vibdelay;
@@ -699,8 +699,7 @@ public:
         }
         void resetAllControllers()
         {
-            bendSrc = 0.0;
-            bend = 0.0;
+            bend = 0;
             bendsense_msb = 2;
             bendsense_lsb = 0;
             updateBendSensitivity();
@@ -724,9 +723,8 @@ public:
         }
         void updateBendSensitivity()
         {
-            int cent = bendsense_msb + static_cast<int>(static_cast<double>(bendsense_lsb) * (1.0 / 128.0));
-            bendsense = static_cast<double>(cent) / 8192.0;
-            bend = bendSrc * bendsense;
+            int cent = bendsense_msb * 128 + bendsense_lsb;
+            bendsense = cent * (1.0 / (128 * 8192));
         }
         MIDIchannel()
         {


### PR DESCRIPTION
Proposing alternative to the pitchbend fix I'm in disagreement with.

Instead of updating pitch when bend sensitivity events are coming, I do this:
Do NOT premultiply pitchbend with bendsense when the pitchbend event arrives.
Conserve the midi value stored, and wait in order to do this multiplication late, at the time of note-on.
What do you think?

~~Still, I'm not convinced if resetting bend on `resetAllControllers` is a proper thing to do.~~
EDIT it's the good thing to reset pitch bend on this event