### PR TITLE
library version string for HQ variant

### DIFF
--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -518,7 +518,11 @@ ADLMIDI_EXPORT int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulato
 
 ADLMIDI_EXPORT const char *adl_linkedLibraryVersion()
 {
+#if !defined(ADLMIDI_ENABLE_HQ_RESAMPLER)
     return ADLMIDI_VERSION;
+#else
+    return ADLMIDI_VERSION " (HQ)";
+#endif
 }
 
 ADLMIDI_EXPORT const ADL_Version *adl_linkedVersion()

--- a/utils/midiplay/adlmidiplay.cpp
+++ b/utils/midiplay/adlmidiplay.cpp
@@ -404,6 +404,7 @@ int main(int argc, char **argv)
     adl_switchEmulator(myDevice, emulator);
     #endif
 
+    std::fprintf(stdout, " - Library version %s\n", adl_linkedLibraryVersion());
     #ifdef HARDWARE_OPL3
     std::fprintf(stdout, " - Hardware OPL3 chip in use\n");
     #else


### PR DESCRIPTION
The same modification of the version string as in OPNMIDI.

On a side note: I observe now `genadldata` has a failing link step in the HQ build. Undefined references to zita library symbols.