### PR TITLE
add skeleton of sysex implementation with API

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -237,6 +237,9 @@ extern const char *adl_errorInfo(struct ADL_MIDIPlayer *device);
 /*Initialize ADLMIDI Player device*/
 extern struct ADL_MIDIPlayer *adl_init(long sample_rate);
 
+/*Set 7-bit device identifier (default $10, $7f reserved)*/
+extern int adl_setDeviceIdentifier(struct ADL_MIDIPlayer *device, ADL_UInt8 id);
+
 /*Load MIDI file from File System*/
 extern int adl_openFile(struct ADL_MIDIPlayer *device, const char *filePath);
 
@@ -363,6 +366,9 @@ extern void adl_rt_bankChangeLSB(struct ADL_MIDIPlayer *device, ADL_UInt8 channe
 extern void adl_rt_bankChangeMSB(struct ADL_MIDIPlayer *device, ADL_UInt8 channel, ADL_UInt8 msb);
 /*Change bank by absolute signed value*/
 extern void adl_rt_bankChange(struct ADL_MIDIPlayer *device, ADL_UInt8 channel, ADL_SInt16 bank);
+
+/*Perform a system exclusive message*/
+extern int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const ADL_UInt8 *msg, unsigned size);
 
 
 /**Hooks**/

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -68,6 +68,17 @@ ADLMIDI_EXPORT struct ADL_MIDIPlayer *adl_init(long sample_rate)
     return midi_device;
 }
 
+ADLMIDI_EXPORT int adl_setDeviceIdentifier(ADL_MIDIPlayer *device, ADL_UInt8 id)
+{
+    if(!device || id >= 0x7f)
+        return -1;
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    if(!play)
+        return -1;
+    play->setDeviceId(id);
+    return 0;
+}
+
 ADLMIDI_EXPORT int adl_setNumChips(ADL_MIDIPlayer *device, int numCards)
 {
     if(device == NULL)
@@ -1266,4 +1277,14 @@ ADLMIDI_EXPORT void adl_rt_bankChange(struct ADL_MIDIPlayer *device, ADL_UInt8 c
     if(!player)
         return;
     player->realTime_BankChange(channel, (uint16_t)bank);
+}
+
+ADLMIDI_EXPORT int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const ADL_UInt8 *msg, unsigned size)
+{
+    if(!device)
+        return -1;
+    MIDIplay *player = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    if(!player)
+        return -1;
+    return player->realTime_SysEx(msg, size);
 }

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1479,6 +1479,17 @@ bool MIDIplay::realTime_SysEx(const uint8_t *msg, unsigned size)
     {
     default:
         break;
+    case Manufacturer_UniversalNonRealtime:
+    case Manufacturer_UniversalRealtime:
+        if (size >= 2)
+        {
+            bool realtime = manufacturer == Manufacturer_UniversalRealtime;
+            uint16_t address = (uint16_t)(((msg[0] & 0x7fU) << 8) | (msg[1] & 0x7fU));
+            msg += 2;
+            size -= 2;
+            return doUniversalSysEx(realtime, address, msg, size);
+        }
+        break;
     case Manufacturer_Yamaha:
         /*TODO*/
         break;
@@ -1516,6 +1527,25 @@ bool MIDIplay::realTime_SysEx(const uint8_t *msg, unsigned size)
     return false;
 }
 
+bool MIDIplay::doUniversalSysEx(bool realtime, uint16_t address, const uint8_t *data, unsigned size)
+{
+    switch((realtime << 16) | address)
+    {
+        case (0 << 16) | 0x0901U: // GM System On
+            /*TODO*/
+            break;
+        case (1 << 16) | 0x0401U: // MIDI Master Volume
+            if(size != 2)
+                break;
+            unsigned volume = (data[0] & 0x7FU) | ((data[1] & 0x7FU) << 7);
+            /*TODO*/
+            (void)volume;
+            break;
+    }
+
+    return false;
+}
+
 bool MIDIplay::doRolandSysEx(uint8_t model, uint8_t mode, uint32_t address, const uint8_t *data, unsigned size)
 {
     if(mode != RolandMode_Send) // don't have MIDI-Out reply ability
@@ -1525,7 +1555,7 @@ bool MIDIplay::doRolandSysEx(uint8_t model, uint8_t mode, uint32_t address, cons
     {
     case (RolandModel_GS << 24U) | 0x40007F: // reset
         if(size != 1)
-            return false;
+            break;
         uint8_t value = data[0] & 0x7f;
         /*TODO*/
         (void)value;

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -680,6 +680,7 @@ bool MIDIplay::buildTrackData()
 
 MIDIplay::MIDIplay(unsigned long sampleRate):
     cmf_percussion_mode(false),
+    m_sysExDeviceId(0x10),
     m_arpeggioCounter(0)
 #if defined(ADLMIDI_AUDIO_TICK_HANDLER)
     , m_audioTickCounter(0)
@@ -1457,6 +1458,81 @@ void MIDIplay::realTime_BankChange(uint8_t channel, uint16_t bank)
     channel = channel % 16;
     Ch[channel].bank_lsb = uint8_t(bank & 0xFF);
     Ch[channel].bank_msb = uint8_t((bank >> 8) & 0xFF);
+}
+
+void MIDIplay::setDeviceId(uint8_t id)
+{
+    m_sysExDeviceId = id;
+}
+
+bool MIDIplay::realTime_SysEx(const uint8_t *msg, unsigned size)
+{
+    if (size < 4 || msg[0] != 0xf0 || msg[size - 1] != 0xf7 ||
+        (msg[2] != m_sysExDeviceId && msg[2] != 0x7f))
+        return false;
+
+    uint8_t manufacturer = msg[1];
+    msg += 3;
+    size -= 4;
+
+    switch(manufacturer)
+    {
+    default:
+        break;
+    case Manufacturer_Yamaha:
+        /*TODO*/
+        break;
+    case Manufacturer_Roland:
+        if(size >= 6)
+        {
+            uint8_t model = msg[0] & 0x7f;
+            uint8_t mode = msg[1] & 0x7f;
+            uint8_t checksum = msg[size - 1] & 0x7f;
+
+            msg += 2;
+            size -= 3;
+
+#if !defined(ADLMIDI_SKIP_ROLAND_CHECKSUM)
+            unsigned checkvalue = 0;
+            for(unsigned i = 0; i < size; ++i)
+                checkvalue += msg[i];
+            checkvalue = (128 - (checkvalue & 127)) & 127;
+            if(checkvalue != checksum)
+                break;
+#endif
+
+            uint32_t address =
+                ((msg[0] & 0x7fU) << 16) |
+                ((msg[1] & 0x7fU) << 8) |
+                (msg[2] & 0x7fU);
+            msg += 3;
+            size -= 3;
+
+            return doRolandSysEx(model, mode, address, msg, size);
+        }
+        break;
+    }
+
+    return false;
+}
+
+bool MIDIplay::doRolandSysEx(uint8_t model, uint8_t mode, uint32_t address, const uint8_t *data, unsigned size)
+{
+    if(mode != RolandMode_Send) // don't have MIDI-Out reply ability
+        return false;
+
+    switch(((unsigned)model << 24U) | address)
+    {
+    case (RolandModel_GS << 24U) | 0x40007F: // reset
+        if(size != 1)
+            return false;
+        uint8_t value = data[0] & 0x7f;
+        /*TODO*/
+        (void)value;
+        return true;
+    }
+
+    return false;
 }
 
 void MIDIplay::realTime_panic()

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -984,6 +984,7 @@ public:
 
     std::vector<MIDIchannel> Ch;
     bool cmf_percussion_mode;
+    uint8_t m_sysExDeviceId;
 
     MIDIEventHooks hooks;
 
@@ -1198,12 +1199,34 @@ public:
     void realTime_BankChangeMSB(uint8_t channel, uint8_t msb);
     void realTime_BankChange(uint8_t channel, uint16_t bank);
 
+    void setDeviceId(uint8_t id);
+    bool realTime_SysEx(const uint8_t *msg, unsigned size);
+
     void realTime_panic();
 
 #if defined(ADLMIDI_AUDIO_TICK_HANDLER)
     // Audio rate tick handler
     void AudioTick(uint32_t chipId, uint32_t rate);
 #endif
+
+private:
+    enum
+    {
+        Manufacturer_Roland = 0x41,
+        Manufacturer_Yamaha = 0x43
+    };
+    enum
+    {
+        RolandMode_Request = 0x11,
+        RolandMode_Send = 0x12
+    };
+    enum
+    {
+        RolandModel_GS = 0x42,
+        RolandModel_SC55 = 0x45
+    };
+
+    bool doRolandSysEx(uint8_t model, uint8_t mode, uint32_t address, const uint8_t *data, unsigned size);
 
 private:
     enum

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -1212,20 +1212,23 @@ public:
 private:
     enum
     {
-        Manufacturer_Roland = 0x41,
-        Manufacturer_Yamaha = 0x43
+        Manufacturer_Roland               = 0x41,
+        Manufacturer_Yamaha               = 0x43,
+        Manufacturer_UniversalNonRealtime = 0x7E,
+        Manufacturer_UniversalRealtime    = 0x7F
     };
     enum
     {
         RolandMode_Request = 0x11,
-        RolandMode_Send = 0x12
+        RolandMode_Send    = 0x12
     };
     enum
     {
-        RolandModel_GS = 0x42,
+        RolandModel_GS   = 0x42,
         RolandModel_SC55 = 0x45
     };
 
+    bool doUniversalSysEx(bool realtime, uint16_t address, const uint8_t *data, unsigned size);
     bool doRolandSysEx(uint8_t model, uint8_t mode, uint32_t address, const uint8_t *data, unsigned size);
 
 private:


### PR DESCRIPTION
In RT only not sequencer. It introduces two API for sysex handling.
The code to recognize GS and model-specific Roland is written and was quickly tested (incl checksum).