### PR TITLE
Split midi sequencer and sysex 2

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1046,7 +1046,7 @@ void MIDIplay::NoteUpdate(uint16_t MidCh,
                 //volume = (int)(volume * std::sqrt( (double) ch[c].users.size() ));
 
                 // The formula below: SOLVE(V=127^4 * 2^( (A-63.49999) / 8), A)
-                volume = volume > (8725 * 127) ? static_cast<uint32_t>(std::log(static_cast<double>(volume) * (1.0 / 127.0)) * 11.541561 + (0.5 - 104.22845)) : 0;
+                volume = volume > (8725 * 127) ? static_cast<uint32_t>(std::log(static_cast<double>(volume)) * 11.541560327111707 - 1.601379199767093e+02) : 0;
                 // The incorrect formula below: SOLVE(V=127^4 * (2^(A/63)-1), A)
                 //opl.Touch_Real(c, volume>(11210*127) ? 91.61112 * std::log((4.8819E-7/127)*volume + 1.0)+0.5 : 0);
 

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -867,8 +867,8 @@ bool MIDIplay::doYamahaSysEx(unsigned dev, const uint8_t *data, size_t size)
             if(size != 1)
                 break;
             unsigned value = data[0] & 0x7F;
-            /*TODO*/
             (void)value;
+            realTime_ResetState();
             return true;
         }
 

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -606,7 +606,7 @@ void MIDIplay::realTime_Controller(uint8_t channel, uint8_t type, uint8_t value)
         break;
 
     case 120: // All sounds off
-        NoteUpdate_All(channel, Upt_OffMute);
+        NoteUpdate_All(channel, Upd_OffMute);
         break;
 
     case 123: // All notes off
@@ -755,10 +755,10 @@ bool MIDIplay::doUniversalSysEx(unsigned dev, bool realtime, const uint8_t *data
     switch(((unsigned)realtime << 16) | address)
     {
         case (0 << 16) | 0x0901: // GM System On
-            /*TODO*/
+            realTime_ResetState();
             return true;
         case (0 << 16) | 0x0902: // GM System Off
-            /*TODO*/
+            realTime_ResetState();
             return true;
         case (1 << 16) | 0x0401: // MIDI Master Volume
             if(size != 2)
@@ -814,8 +814,8 @@ bool MIDIplay::doRolandSysEx(unsigned dev, const uint8_t *data, size_t size)
         if(size != 1 || (dev & 0xF0) != 0x10)
             break;
         unsigned mode = data[0] & 0x7F;
-        /*TODO*/
         (void)mode;
+        realTime_ResetState();
         return true;
     }
     case (RolandModel_GS << 24) | 0x40007F: // Mode Set
@@ -823,8 +823,8 @@ bool MIDIplay::doRolandSysEx(unsigned dev, const uint8_t *data, size_t size)
         if(size != 1 || (dev & 0xF0) != 0x10)
             break;
         unsigned value = data[0] & 0x7F;
-        /*TODO*/
         (void)value;
+        realTime_ResetState();
         return true;
     }
     }

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -723,6 +723,7 @@ public:
 
     std::vector<MIDIchannel> Ch;
     bool cmf_percussion_mode;
+    uint8_t m_masterVolume;
     uint8_t m_sysExDeviceId;
 
     MIDIEventHooks hooks;

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -980,7 +980,7 @@ private:
         Upd_All    = Upd_Pan + Upd_Volume + Upd_Pitch,
         Upd_Off    = 0x20,
         Upd_Mute   = 0x40,
-        Upt_OffMute = Upd_Off + Upd_Mute
+        Upd_OffMute = Upd_Off + Upd_Mute
     };
 
     void NoteUpdate(uint16_t MidCh,


### PR DESCRIPTION
Handle resets and master volume.
Master volume handles MSB only for 7bit resolution. It was for a quick solution because it makes formulas simpler to adapt.