### PR TITLE
glide: handle for all the midi channels

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1632,7 +1632,9 @@ retry_arpeggio:
 
 void MIDIplay::UpdateGlide(double amount)
 {
-    for(unsigned channel = 0; channel < 16; ++channel)
+    unsigned num_channels = Ch.size();
+
+    for(unsigned channel = 0; channel < num_channels; ++channel)
     {
         MIDIchannel &midiChan = Ch[channel];
         if(midiChan.gliding_note_count == 0)


### PR DESCRIPTION
Doing the iteration on channels the same as other code does, because the MIDI channels seem not fixed at 16.
