### PR TITLE
color attribute for channel descriptor

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1761,7 +1761,11 @@ void MIDIplay::describeChannels(char *str, char *attr, size_t size)
             }
         }
 
-        attr[index] = '\0';  // TODO
+        uint8_t attribute = 0;
+        if (loc)  // 4-bit color index of MIDI channel
+            attribute |= (uint8_t)(loc->loc.MidCh & 0xF);
+
+        attr[index] = (char)attribute;
     }
 
     str[index] = 0;


### PR DESCRIPTION
This puts a color ID which identifies the MIDI channel in low 4 bits of the channel description.
This extends API to allow implementing a colored output.
(adljack currently has a monochrome output of channels)

Upper bits are reserved for keeping more infos as necessary. (key release was discussed before)
