### PR TITLE
Track options

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -636,6 +636,33 @@ extern void adl_setTempo(struct ADL_MIDIPlayer *device, double tempo);
  */
 extern int adl_atEnd(struct ADL_MIDIPlayer *device);
 
+/**
+ * @brief Returns the number of tracks of the current sequence
+ * @param device Instance of the library
+ * @return Count of tracks in the current sequence
+ */
+extern size_t adl_trackCount(struct ADL_MIDIPlayer *device);
+
+/**
+ * @brief Track options
+ */
+enum ADLMIDI_TrackOptions
+{
+    /*! Enabled track */
+    ADL_TrackOption_On   = 1,
+    /*! Disabled track */
+    ADL_TrackOption_Off  = 2,
+    /*! Solo track */
+    ADL_TrackOption_Solo = 3,
+};
+
+/**
+ * @brief Sets options on a track of the current sequence
+ * @param device Instance of the library
+ * @param trackNumber Identifier of the designated track.
+ * @return 0 on success, <0 when any error has occurred
+ */
+extern int adl_setTrackOptions(struct ADL_MIDIPlayer *device, size_t trackNumber, unsigned trackOptions);
 
 
 

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -1356,6 +1356,63 @@ ADLMIDI_EXPORT int adl_atEnd(struct ADL_MIDIPlayer *device)
 #endif
 }
 
+ADLMIDI_EXPORT size_t adl_trackCount(struct ADL_MIDIPlayer *device)
+{
+#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
+    if(!device)
+        return 0;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    if(!play)
+        return 0;
+    return play->m_sequencer.getTrackCount();
+#else
+    ADL_UNUSED(device);
+    return 0;
+#endif
+}
+
+ADLMIDI_EXPORT int adl_setTrackOptions(struct ADL_MIDIPlayer *device, size_t trackNumber, unsigned trackOptions)
+{
+#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
+    if(!device)
+        return -1;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    if(!play)
+        return -1;
+    MidiSequencer &seq = play->m_sequencer;
+
+    unsigned enableFlag = trackOptions & 3;
+    trackOptions &= ~3u;
+
+    // handle on/off/solo
+    switch(enableFlag)
+    {
+    default:
+        break;
+    case ADL_TrackOption_On:
+    case ADL_TrackOption_Off:
+        if(!seq.setTrackEnabled(trackNumber, enableFlag == ADL_TrackOption_On))
+            return -1;
+        break;
+    case ADL_TrackOption_Solo:
+        seq.setSoloTrack(trackNumber);
+        break;
+    }
+
+    // handle others...
+    if(trackOptions != 0)
+        return -1;
+
+    return 0;
+
+#else
+    ADL_UNUSED(device);
+    ADL_UNUSED(trackNumber);
+    ADL_UNUSED(trackOptions);
+    return -1;
+#endif
+}
+
 ADLMIDI_EXPORT void adl_panic(struct ADL_MIDIPlayer *device)
 {
     if(!device)

--- a/src/midi_sequencer.hpp
+++ b/src/midi_sequencer.hpp
@@ -343,6 +343,11 @@ private:
     //! Are loop points invalid?
     bool    m_invalidLoop; /*Loop points are invalid (loopStart after loopEnd or loopStart and loopEnd are on same place)*/
 
+    //! Whether the nth track has playback disabled
+    std::vector<bool> m_trackDisable;
+    //! Index of solo track, or max for disabled
+    size_t m_trackSolo;
+
     //! File parsing errors string (adding into m_errorString on aborting of the process)
     std::string m_parsingErrorsString;
     //! Common error string
@@ -363,6 +368,26 @@ public:
      * @return File format type enumeration
      */
     FileFormat getFormat();
+
+    /**
+     * @brief Returns the number of tracks
+     * @return Track count
+     */
+    size_t getTrackCount() const;
+
+    /**
+     * @brief Sets whether a track is playing
+     * @param track Track identifier
+     * @param enable Whether to enable track playback
+     * @return true on success, false if there was no such track
+     */
+    bool setTrackEnabled(size_t track, bool enable);
+
+    /**
+     * @brief Enables or disables solo on a track
+     * @param track Identifier of solo track, or max to disable
+     */
+    void setSoloTrack(size_t track);
 
     /**
      * @brief Get the list of CMF instruments (CMF only)

--- a/utils/midiplay/adlmidiplay.cpp
+++ b/utils/midiplay/adlmidiplay.cpp
@@ -342,6 +342,8 @@ int main(int argc, char **argv)
     int emulator = ADLMIDI_EMU_NUKED;
 #endif
 
+    size_t soloTrack = ~(size_t)0;
+
 #if !defined(HARDWARE_OPL3) && !defined(OUTPUT_WAVE_ONLY)
     g_audioFormat.type = ADLMIDI_SampleType_S16;
     g_audioFormat.containerSize = sizeof(Sint16);
@@ -404,6 +406,18 @@ int main(int argc, char **argv)
             multibankFromEnbededTest = true;
         else if(!std::strcmp("-s", argv[2]))
             adl_setScaleModulators(myDevice, 1);//Turn on modulators scaling by volume
+
+        else if(!std::strcmp("--solo", argv[2]))
+        {
+            if(argc <= 3)
+            {
+                printError("The option --solo requires an argument!\n");
+                return 1;
+            }
+            soloTrack = std::strtoul(argv[3], NULL, 0);
+            had_option = true;
+        }
+
         else break;
 
         std::copy(argv + (had_option ? 4 : 3),
@@ -584,6 +598,14 @@ int main(int argc, char **argv)
     {
         printError(adl_errorInfo(myDevice));
         return 2;
+    }
+
+    std::fprintf(stdout, " - Track count: %lu\n", (unsigned long)adl_trackCount(myDevice));
+
+    if(soloTrack != ~(size_t)0)
+    {
+        std::fprintf(stdout, " - Solo track: %lu\n", (unsigned long)soloTrack);
+        adl_setTrackOptions(myDevice, soloTrack, ADL_TrackOption_Solo);
     }
 
     std::fprintf(stdout, " - File [%s] opened!\n", musPath.c_str());


### PR DESCRIPTION
#30 

This adds an API to set tracks as On/Off/Solo.
One can play solo tracks in `midiplay` with option `--solo N`.

Example of System shock XMI playback
`./build/adlmidiplay genmidi/thm7.xmi --solo 4`

To discuss is the case of SMF, where formats have track 0 as a special track for Meta-events.
Solo mode on another track will make track 0 disabled, and may produce undesired effect.