### PR TITLE
SMF track 0 on solo/off mode

### DIFF
--- a/src/midi_sequencer.hpp
+++ b/src/midi_sequencer.hpp
@@ -291,6 +291,8 @@ public:
 private:
     //! Music file format type. MIDI is default.
     FileFormat m_format;
+    //! SMF format identifier.
+    unsigned m_smfFormat;
 
     //! Current position
     Position m_currentPosition;


### PR DESCRIPTION
Special case for SMF where timing events of track 0 must be always used.
This keeps `smfFormat` as sequencer variable.

Outside of SMF format: it will be 2 for multi-track XMI, otherwise it will be taken as 0
If invalid value in SMF it has fallback as 1. (which I think to be the most compatible)

I will do the special case in format 0 as well as format 1, to protect of non-standard smf which will lie about their format.