### PR TITLE
xmi: handle AIL callback trigger

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -664,6 +664,24 @@ enum ADLMIDI_TrackOptions
  */
 extern int adl_setTrackOptions(struct ADL_MIDIPlayer *device, size_t trackNumber, unsigned trackOptions);
 
+/**
+ * @brief Handler of callback trigger events
+ * @param userData Pointer to user data (usually, context of something)
+ * @param trigger Value of the event which triggered this callback.
+ * @param track Identifier of the track which triggered this callback.
+ */
+typedef void (*ADL_TriggerHandler)(void *userData, unsigned trigger, size_t track);
+
+/**
+ * @brief Defines a handler for callback trigger events
+ * @param device Instance of the library
+ * @param handler Handler to invoke from the sequencer when triggered, or NULL.
+ * @param userData Instance of the library
+ * @return 0 on success, <0 when any error has occurred
+ */
+extern int adl_setTriggerHandler(struct ADL_MIDIPlayer *device, ADL_TriggerHandler handler, void *userData);
+
+
 
 
 /* ======== Meta-Tags ======== */

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -1413,6 +1413,25 @@ ADLMIDI_EXPORT int adl_setTrackOptions(struct ADL_MIDIPlayer *device, size_t tra
 #endif
 }
 
+ADLMIDI_EXPORT int adl_setTriggerHandler(struct ADL_MIDIPlayer *device, ADL_TriggerHandler handler, void *userData)
+{
+#ifndef ADLMIDI_DISABLE_MIDI_SEQUENCER
+    if(!device)
+        return -1;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    if(!play)
+        return -1;
+    MidiSequencer &seq = play->m_sequencer;
+    seq.setTriggerHandler(handler, userData);
+    return 0;
+#else
+    ADL_UNUSED(device);
+    ADL_UNUSED(handler);
+    ADL_UNUSED(userData);
+    return -1;
+#endif
+}
+
 ADLMIDI_EXPORT void adl_panic(struct ADL_MIDIPlayer *device)
 {
     if(!device)

--- a/src/midi_sequencer.hpp
+++ b/src/midi_sequencer.hpp
@@ -131,6 +131,8 @@ class BW_MidiSequencer
             ST_LOOPSTACK_END   = 0xE5,//size == 0 <CUSTOM>
             //! [Non-Standard] Loop End point with support of multi-loops
             ST_LOOPSTACK_BREAK = 0xE6,//size == 0 <CUSTOM>
+            //! [Non-Standard] Callback Trigger
+            ST_CALLBACK_TRIGGER = 0xE7,//size == 1 <CUSTOM>
         };
         //! Main type of event
         uint8_t type;
@@ -453,6 +455,19 @@ private:
     //! Index of solo track, or max for disabled
     size_t m_trackSolo;
 
+    /**
+     * @brief Handler of callback trigger events
+     * @param userData Pointer to user data (usually, context of something)
+     * @param trigger Value of the event which triggered this callback.
+     * @param track Identifier of the track which triggered this callback.
+     */
+    typedef void (*TriggerHandler)(void *userData, unsigned trigger, size_t track);
+
+    //! Handler of callback trigger events
+    TriggerHandler m_triggerHandler;
+    //! User data of callback trigger events
+    void *m_triggerUserData;
+
     //! File parsing errors string (adding into m_errorString on aborting of the process)
     std::string m_parsingErrorsString;
     //! Common error string
@@ -493,6 +508,13 @@ public:
      * @param track Identifier of solo track, or max to disable
      */
     void setSoloTrack(size_t track);
+
+    /**
+     * @brief Defines a handler for callback trigger events
+     * @param handler Handler to invoke from the sequencer when triggered, or NULL.
+     * @param userData Instance of the library
+     */
+    void setTriggerHandler(TriggerHandler handler, void *userData);
 
     /**
      * @brief Get the list of CMF instruments (CMF only)


### PR DESCRIPTION
#30 

Implement AIL callback trigger (`thm0.xmi` first track)

I make this controller event a `ST_SPECIAL` in the sequencer, as done for loop events before, and covered under the XMI file format case. But if prefered, it could be left in controller form.

This is modeled after AIL functions `AIL_install_callback`, `AIL_cancel_callback`, except I implement as one function. There is one callback to handle all the triggers, and the trigger value (CC value) is received by the callback.