### PR TITLE
preserve the data of operator 3-4 in internal storage, regardless of being 2op/4op

### DIFF
--- a/src/adldata.hh
+++ b/src/adldata.hh
@@ -49,6 +49,9 @@ struct adlinsdata
 {
     enum { Flag_Pseudo4op = 0x01, Flag_NoSound = 0x02, Flag_Real4op = 0x04 };
 
+    enum { Flag_RM_BassDrum  = 0x08, Flag_RM_Snare = 0x10, Flag_RM_TomTom = 0x18,
+           Flag_RM_Cymbal = 0x20, Flag_RM_HiHat = 0x28, Mask_RhythmMode = 0x38 };
+
     uint16_t    adlno1, adlno2;
     uint8_t     tone;
     uint8_t     flags;

--- a/src/adlmidi_cvt.hpp
+++ b/src/adlmidi_cvt.hpp
@@ -1,0 +1,122 @@
+/*
+ * libADLMIDI is a free MIDI to WAV conversion library with OPL3 emulation
+ *
+ * Original ADLMIDI code: Copyright (c) 2010-2014 Joel Yliluoma <bisqwit@iki.fi>
+ * ADLMIDI Library API:   Copyright (c) 2015-2018 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * Library is based on the ADLMIDI, a MIDI player for Linux and Windows with OPL3 emulation:
+ * http://iki.fi/bisqwit/source/adlmidi.html
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "adldata.hh"
+#include "wopl/wopl_file.h"
+#include <cmath>
+
+template <class WOPLI>
+static void cvt_generic_to_FMIns(adlinsdata2 &ins, const WOPLI &in)
+{
+    ins.voice2_fine_tune = 0.0;
+    int8_t voice2_fine_tune = in.second_voice_detune;
+    if(voice2_fine_tune != 0)
+    {
+        if(voice2_fine_tune == 1)
+            ins.voice2_fine_tune = 0.000025;
+        else if(voice2_fine_tune == -1)
+            ins.voice2_fine_tune = -0.000025;
+        else
+            ins.voice2_fine_tune = voice2_fine_tune * (15.625 / 1000.0);
+    }
+
+    ins.tone = in.percussion_key_number;
+    ins.flags = (in.inst_flags & WOPL_Ins_4op) && (in.inst_flags & WOPL_Ins_Pseudo4op) ? adlinsdata::Flag_Pseudo4op : 0;
+    ins.flags|= (in.inst_flags & WOPL_Ins_4op) && ((in.inst_flags & WOPL_Ins_Pseudo4op) == 0) ? adlinsdata::Flag_Real4op : 0;
+    ins.flags|= (in.inst_flags & WOPL_Ins_IsBlank) ? adlinsdata::Flag_NoSound : 0;
+    ins.flags|= in.inst_flags & WOPL_RhythmModeMask;
+
+    for(size_t op = 0, slt = 0; op < 4; op++, slt++)
+    {
+        ins.adl[slt].carrier_E862 =
+            ((static_cast<uint32_t>(in.operators[op].waveform_E0) << 24) & 0xFF000000) //WaveForm
+            | ((static_cast<uint32_t>(in.operators[op].susrel_80) << 16) & 0x00FF0000) //SusRel
+            | ((static_cast<uint32_t>(in.operators[op].atdec_60) << 8) & 0x0000FF00)   //AtDec
+            | ((static_cast<uint32_t>(in.operators[op].avekf_20) << 0) & 0x000000FF);  //AVEKM
+        ins.adl[slt].carrier_40 = in.operators[op].ksl_l_40;//KSLL
+
+        op++;
+        ins.adl[slt].modulator_E862 =
+            ((static_cast<uint32_t>(in.operators[op].waveform_E0) << 24) & 0xFF000000) //WaveForm
+            | ((static_cast<uint32_t>(in.operators[op].susrel_80) << 16) & 0x00FF0000) //SusRel
+            | ((static_cast<uint32_t>(in.operators[op].atdec_60) << 8) & 0x0000FF00)   //AtDec
+            | ((static_cast<uint32_t>(in.operators[op].avekf_20) << 0) & 0x000000FF);  //AVEKM
+        ins.adl[slt].modulator_40 = in.operators[op].ksl_l_40;//KSLL
+    }
+
+    ins.adl[0].finetune = static_cast<int8_t>(in.note_offset1);
+    ins.adl[0].feedconn = in.fb_conn1_C0;
+    ins.adl[1].finetune = static_cast<int8_t>(in.note_offset2);
+    ins.adl[1].feedconn = in.fb_conn2_C0;
+
+    ins.ms_sound_kon  = in.delay_on_ms;
+    ins.ms_sound_koff = in.delay_off_ms;
+}
+
+template <class WOPLI>
+static void cvt_FMIns_to_generic(WOPLI &ins, const adlinsdata2 &in)
+{
+    ins.second_voice_detune = 0;
+    double voice2_fine_tune = in.voice2_fine_tune;
+    if(voice2_fine_tune != 0)
+    {
+        if(voice2_fine_tune > 0 && voice2_fine_tune <= 0.000025)
+            ins.second_voice_detune = 1;
+        else if(voice2_fine_tune < 0 && voice2_fine_tune >= -0.000025)
+            ins.second_voice_detune = -1;
+        else
+        {
+            long value = static_cast<long>(std::round(voice2_fine_tune * (1000.0 / 15.625)));
+            value = (value < -128) ? -128 : value;
+            value = (value > +127) ? +127 : value;
+            ins.second_voice_detune = static_cast<int8_t>(value);
+        }
+    }
+
+    ins.percussion_key_number = in.tone;
+    ins.inst_flags = (in.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? WOPL_Ins_4op : 0;
+    ins.inst_flags|= (in.flags & adlinsdata::Flag_Pseudo4op) ? WOPL_Ins_Pseudo4op : 0;
+    ins.inst_flags|= (in.flags & adlinsdata::Flag_NoSound) ? WOPL_Ins_IsBlank : 0;
+    ins.inst_flags |= in.flags & adlinsdata::Mask_RhythmMode;
+
+    for(size_t op = 0; op < 4; op++)
+    {
+        const adldata &in2op = in.adl[(op < 2) ? 0 : 1];
+        uint32_t regE862 = ((op & 1) == 0) ? in2op.carrier_E862 : in2op.modulator_E862;
+        uint8_t reg40 = ((op & 1) == 0) ? in2op.carrier_40 : in2op.modulator_40;
+
+        ins.operators[op].waveform_E0 = static_cast<uint8_t>(regE862 >> 24);
+        ins.operators[op].susrel_80 = static_cast<uint8_t>(regE862 >> 16);
+        ins.operators[op].atdec_60 = static_cast<uint8_t>(regE862 >> 8);
+        ins.operators[op].avekf_20 = static_cast<uint8_t>(regE862 >> 0);
+        ins.operators[op].ksl_l_40 = reg40;
+    }
+
+    ins.note_offset1 = in.adl[0].finetune;
+    ins.fb_conn1_C0 = in.adl[0].feedconn;
+    ins.note_offset2 = in.adl[1].finetune;
+    ins.fb_conn2_C0 = in.adl[1].feedconn;
+
+    ins.delay_on_ms = in.ms_sound_kon;
+    ins.delay_off_ms = in.ms_sound_koff;
+}

--- a/src/adlmidi_load.cpp
+++ b/src/adlmidi_load.cpp
@@ -58,8 +58,7 @@ static void cvt_generic_to_FMIns(adlinsdata2 &ins, const WOPLI &in)
     ins.flags|= (in.inst_flags & WOPL_Ins_4op) && ((in.inst_flags & WOPL_Ins_Pseudo4op) == 0) ? adlinsdata::Flag_Real4op : 0;
     ins.flags|= (in.inst_flags & WOPL_Ins_IsBlank) ? adlinsdata::Flag_NoSound : 0;
 
-    bool fourOps = (in.inst_flags & WOPL_Ins_4op) || (in.inst_flags & WOPL_Ins_Pseudo4op);
-    for(size_t op = 0, slt = 0; op < static_cast<size_t>(fourOps ? 4 : 2); op++, slt++)
+    for(size_t op = 0, slt = 0; op < 4; op++, slt++)
     {
         ins.adl[slt].carrier_E862 =
             ((static_cast<uint32_t>(in.operators[op].waveform_E0) << 24) & 0xFF000000) //WaveForm
@@ -79,13 +78,8 @@ static void cvt_generic_to_FMIns(adlinsdata2 &ins, const WOPLI &in)
 
     ins.adl[0].finetune = static_cast<int8_t>(in.note_offset1);
     ins.adl[0].feedconn = in.fb_conn1_C0;
-    if(!fourOps)
-        ins.adl[1] = ins.adl[0];
-    else
-    {
-        ins.adl[1].finetune = static_cast<int8_t>(in.note_offset2);
-        ins.adl[1].feedconn = in.fb_conn2_C0;
-    }
+    ins.adl[1].finetune = static_cast<int8_t>(in.note_offset2);
+    ins.adl[1].feedconn = in.fb_conn2_C0;
 
     ins.ms_sound_kon  = in.delay_on_ms;
     ins.ms_sound_koff = in.delay_off_ms;
@@ -112,8 +106,7 @@ static void cvt_FMIns_to_generic(WOPLI &ins, const adlinsdata2 &in)
     }
 
     ins.percussion_key_number = in.tone;
-    bool fourOps = (in.flags & adlinsdata::Flag_Pseudo4op) || in.adl[0] != in.adl[1];
-    ins.inst_flags = fourOps ? WOPL_Ins_4op : 0;
+    ins.inst_flags = (in.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? WOPL_Ins_4op : 0;
     ins.inst_flags|= (in.flags & adlinsdata::Flag_Pseudo4op) ? WOPL_Ins_Pseudo4op : 0;
     ins.inst_flags|= (in.flags & adlinsdata::Flag_NoSound) ? WOPL_Ins_IsBlank : 0;
 
@@ -132,16 +125,8 @@ static void cvt_FMIns_to_generic(WOPLI &ins, const adlinsdata2 &in)
 
     ins.note_offset1 = in.adl[0].finetune;
     ins.fb_conn1_C0 = in.adl[0].feedconn;
-    if(!fourOps)
-    {
-        ins.operators[2] = ins.operators[0];
-        ins.operators[3] = ins.operators[1];
-    }
-    else
-    {
-        ins.note_offset2 = in.adl[1].finetune;
-        ins.fb_conn2_C0 = in.adl[1].feedconn;
-    }
+    ins.note_offset2 = in.adl[1].finetune;
+    ins.fb_conn2_C0 = in.adl[1].feedconn;
 
     ins.delay_on_ms = in.ms_sound_kon;
     ins.delay_off_ms = in.ms_sound_koff;

--- a/src/adlmidi_load.cpp
+++ b/src/adlmidi_load.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "adlmidi_private.hpp"
+#include "adlmidi_cvt.hpp"
 #include "wopl/wopl_file.h"
 
 bool MIDIplay::LoadBank(const std::string &filename)
@@ -36,100 +37,6 @@ bool MIDIplay::LoadBank(const void *data, size_t size)
     FileAndMemReader file;
     file.openData(data, size);
     return LoadBank(file);
-}
-
-template <class WOPLI>
-static void cvt_generic_to_FMIns(adlinsdata2 &ins, const WOPLI &in)
-{
-    ins.voice2_fine_tune = 0.0;
-    int8_t voice2_fine_tune = in.second_voice_detune;
-    if(voice2_fine_tune != 0)
-    {
-        if(voice2_fine_tune == 1)
-            ins.voice2_fine_tune = 0.000025;
-        else if(voice2_fine_tune == -1)
-            ins.voice2_fine_tune = -0.000025;
-        else
-            ins.voice2_fine_tune = voice2_fine_tune * (15.625 / 1000.0);
-    }
-
-    ins.tone = in.percussion_key_number;
-    ins.flags = (in.inst_flags & WOPL_Ins_4op) && (in.inst_flags & WOPL_Ins_Pseudo4op) ? adlinsdata::Flag_Pseudo4op : 0;
-    ins.flags|= (in.inst_flags & WOPL_Ins_4op) && ((in.inst_flags & WOPL_Ins_Pseudo4op) == 0) ? adlinsdata::Flag_Real4op : 0;
-    ins.flags|= (in.inst_flags & WOPL_Ins_IsBlank) ? adlinsdata::Flag_NoSound : 0;
-
-    for(size_t op = 0, slt = 0; op < 4; op++, slt++)
-    {
-        ins.adl[slt].carrier_E862 =
-            ((static_cast<uint32_t>(in.operators[op].waveform_E0) << 24) & 0xFF000000) //WaveForm
-            | ((static_cast<uint32_t>(in.operators[op].susrel_80) << 16) & 0x00FF0000) //SusRel
-            | ((static_cast<uint32_t>(in.operators[op].atdec_60) << 8) & 0x0000FF00)   //AtDec
-            | ((static_cast<uint32_t>(in.operators[op].avekf_20) << 0) & 0x000000FF);  //AVEKM
-        ins.adl[slt].carrier_40 = in.operators[op].ksl_l_40;//KSLL
-
-        op++;
-        ins.adl[slt].modulator_E862 =
-            ((static_cast<uint32_t>(in.operators[op].waveform_E0) << 24) & 0xFF000000) //WaveForm
-            | ((static_cast<uint32_t>(in.operators[op].susrel_80) << 16) & 0x00FF0000) //SusRel
-            | ((static_cast<uint32_t>(in.operators[op].atdec_60) << 8) & 0x0000FF00)   //AtDec
-            | ((static_cast<uint32_t>(in.operators[op].avekf_20) << 0) & 0x000000FF);  //AVEKM
-        ins.adl[slt].modulator_40 = in.operators[op].ksl_l_40;//KSLL
-    }
-
-    ins.adl[0].finetune = static_cast<int8_t>(in.note_offset1);
-    ins.adl[0].feedconn = in.fb_conn1_C0;
-    ins.adl[1].finetune = static_cast<int8_t>(in.note_offset2);
-    ins.adl[1].feedconn = in.fb_conn2_C0;
-
-    ins.ms_sound_kon  = in.delay_on_ms;
-    ins.ms_sound_koff = in.delay_off_ms;
-}
-
-template <class WOPLI>
-static void cvt_FMIns_to_generic(WOPLI &ins, const adlinsdata2 &in)
-{
-    ins.second_voice_detune = 0;
-    double voice2_fine_tune = in.voice2_fine_tune;
-    if(voice2_fine_tune != 0)
-    {
-        if(voice2_fine_tune > 0 && voice2_fine_tune <= 0.000025)
-            ins.second_voice_detune = 1;
-        else if(voice2_fine_tune < 0 && voice2_fine_tune >= -0.000025)
-            ins.second_voice_detune = -1;
-        else
-        {
-            long value = static_cast<long>(round(voice2_fine_tune * (1000.0 / 15.625)));
-            value = (value < -128) ? -128 : value;
-            value = (value > +127) ? +127 : value;
-            ins.second_voice_detune = static_cast<int8_t>(value);
-        }
-    }
-
-    ins.percussion_key_number = in.tone;
-    ins.inst_flags = (in.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? WOPL_Ins_4op : 0;
-    ins.inst_flags|= (in.flags & adlinsdata::Flag_Pseudo4op) ? WOPL_Ins_Pseudo4op : 0;
-    ins.inst_flags|= (in.flags & adlinsdata::Flag_NoSound) ? WOPL_Ins_IsBlank : 0;
-
-    for(size_t op = 0; op < 4; op++)
-    {
-        const adldata &in2op = in.adl[(op < 2) ? 0 : 1];
-        uint32_t regE862 = ((op & 1) == 0) ? in2op.carrier_E862 : in2op.modulator_E862;
-        uint8_t reg40 = ((op & 1) == 0) ? in2op.carrier_40 : in2op.modulator_40;
-
-        ins.operators[op].waveform_E0 = static_cast<uint8_t>(regE862 >> 24);
-        ins.operators[op].susrel_80 = static_cast<uint8_t>(regE862 >> 16);
-        ins.operators[op].atdec_60 = static_cast<uint8_t>(regE862 >> 8);
-        ins.operators[op].avekf_20 = static_cast<uint8_t>(regE862 >> 0);
-        ins.operators[op].ksl_l_40 = reg40;
-    }
-
-    ins.note_offset1 = in.adl[0].finetune;
-    ins.fb_conn1_C0 = in.adl[0].feedconn;
-    ins.note_offset2 = in.adl[1].finetune;
-    ins.fb_conn2_C0 = in.adl[1].feedconn;
-
-    ins.delay_on_ms = in.ms_sound_kon;
-    ins.delay_off_ms = in.ms_sound_koff;
 }
 
 void cvt_ADLI_to_FMIns(adlinsdata2 &ins, const ADL_Instrument &in)

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -401,7 +401,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     MIDIchannel::NoteInfo::Phys voices[MIDIchannel::NoteInfo::MaxNumPhysChans] =
     {
         {0, ains->adl[0], false},
-        {0, ains->adl[1], pseudo_4op}
+        {0, (!is_2op) ? ains->adl[1] : ains->adl[0], pseudo_4op}
     };
 #else /* Unfortunately, WatCom can't brace-initialize structure that incluses structure fields */
     MIDIchannel::NoteInfo::Phys voices[MIDIchannel::NoteInfo::MaxNumPhysChans];
@@ -409,7 +409,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     voices[0].ains = ains->adl[0];
     voices[0].pseudo4op = false;
     voices[1].chip_chan = 0;
-    voices[1].ains = ains->adl[1];
+    voices[1].ains = (!is_2op) ? ains->adl[1] : ains->adl[0];
     voices[1].pseudo4op = pseudo_4op;
 #endif /* __WATCOMC__ */
 

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -395,6 +395,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     }
 
     //uint16_t i[2] = { ains->adlno1, ains->adlno2 };
+    bool is_2op = !(ains->flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op));
     bool pseudo_4op = ains->flags & adlinsdata::Flag_Pseudo4op;
 #ifndef __WATCOMC__
     MIDIchannel::NoteInfo::Phys voices[MIDIchannel::NoteInfo::MaxNumPhysChans] =
@@ -457,7 +458,7 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
             if(ccount == 1 && static_cast<int32_t>(a) == adlchannel[0]) continue;
             // ^ Don't use the same channel for primary&secondary
 
-            if(voices[0].ains == voices[1].ains || pseudo_4op/*i[0] == i[1] || pseudo_4op*/)
+            if(is_2op || pseudo_4op)
             {
                 // Only use regular channels
                 uint32_t expected_mode = 0;
@@ -1878,7 +1879,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::DoNote(int note)
     }
     double hertz = 172.00093 * std::exp(0.057762265 * (tone + 0.0));
     int32_t adlchannel[2] = { 0, 3 };
-    if(ains.adl[0] == ains.adl[1])
+    if((ains.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) == 0)
     {
         adlchannel[1] = -1;
         adlchannel[0] = 6; // single-op
@@ -1960,7 +1961,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::NextAdl(int offset)
         }
         std::printf("%s%s%s%u\t",
                     ToneIndication,
-                    ains.adl[0] != ains.adl[1] ? "[2]" : "   ",
+                    (ains.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? "[2]" : "   ",
                     (P->ins_idx == a) ? "->" : "\t",
                     i
                    );

--- a/src/adlmidi_private.cpp
+++ b/src/adlmidi_private.cpp
@@ -56,7 +56,7 @@ int adlRefreshNumCards(ADL_MIDIPlayer *device)
                 adlinsdata2 &ins = it->second.ins[i];
                 if(ins.flags & adlinsdata::Flag_NoSound)
                     continue;
-                if((ins.adl[0] != ins.adl[1]) && ((ins.flags & adlinsdata::Flag_Pseudo4op) == 0))
+                if((ins.flags & adlinsdata::Flag_Real4op) != 0)
                     ++n_fourop[div];
                 ++n_total[div];
             }
@@ -73,7 +73,7 @@ int adlRefreshNumCards(ADL_MIDIPlayer *device)
                 continue;
             ++n_total[a / 128];
             adlinsdata2 ins(adlins[insno]);
-            if(ins.flags & adlinsdata::Flag_Real4op)
+            if((ins.flags & adlinsdata::Flag_Real4op) != 0)
                 ++n_fourop[a / 128];
         }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(bankmap)
+add_subdirectory(conversion)
 
 add_library(Catch-objects OBJECT "common/catch_main.cpp")
 target_include_directories(Catch-objects PRIVATE "common")

--- a/test/conversion/CMakeLists.txt
+++ b/test/conversion/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+set(CMAKE_CXX_STANDARD 11)
+
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/src)
+
+add_executable(ConversionTest conversion.cpp $<TARGET_OBJECTS:Catch-objects>)
+
+set_target_properties(ConversionTest PROPERTIES COMPILE_DEFINITIONS "GSL_THROW_ON_CONTRACT_VIOLATION")
+add_test(NAME ConversionTest COMMAND ConversionTest)

--- a/test/conversion/conversion.cpp
+++ b/test/conversion/conversion.cpp
@@ -1,0 +1,82 @@
+#include <catch.hpp>
+#include <random>
+#include "adlmidi.h"
+#include "adlmidi_cvt.hpp"
+
+static std::mt19937 rng;
+
+static ADL_Instrument random_instrument()
+{
+    ADL_Instrument ins;
+    ins.version = ADLMIDI_InstrumentVersion;
+    ins.note_offset1 = std::uniform_int_distribution<int>(-128, 127)(rng);
+    ins.note_offset2 = std::uniform_int_distribution<int>(-128, 127)(rng);
+    ins.midi_velocity_offset = std::uniform_int_distribution<int>(-128, 127)(rng);
+    ins.second_voice_detune = std::uniform_int_distribution<int>(-128, 127)(rng);
+    ins.percussion_key_number = std::uniform_int_distribution<unsigned>(0, 127)(rng);
+    ins.inst_flags =
+        std::uniform_int_distribution<unsigned>(0, 255)(rng) &
+        (ADLMIDI_Ins_IsBlank|ADLMIDI_Ins_RhythmModeMask);
+    switch (std::uniform_int_distribution<unsigned>(0, 3)(rng)) {
+    case 0:  // 2op
+        ins.inst_flags |= ADLMIDI_Ins_2op;
+        break;
+    case 1:  // pseudo 4op
+        ins.inst_flags |= ADLMIDI_Ins_Pseudo4op;
+        // fall through
+    case 2:  // real 4op
+        ins.inst_flags |= ADLMIDI_Ins_4op;
+        break;
+    }
+    ins.fb_conn1_C0 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+    ins.fb_conn2_C0 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+    ins.delay_on_ms = std::uniform_int_distribution<unsigned>(0, 40000)(rng);
+    ins.delay_off_ms = std::uniform_int_distribution<unsigned>(0, 40000)(rng);
+    for (unsigned op = 0; op < 4; ++op) {
+        ins.operators[op].avekf_20 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+        ins.operators[op].ksl_l_40 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+        ins.operators[op].atdec_60 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+        ins.operators[op].susrel_80 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+        ins.operators[op].waveform_E0 = std::uniform_int_distribution<unsigned>(0, 255)(rng);
+    }
+    return ins;
+}
+
+static void check_instrument_equality(const ADL_Instrument &a, const ADL_Instrument &b)
+{
+    REQUIRE((int)a.note_offset1 == (int)b.note_offset1);
+    REQUIRE((int)a.note_offset2 == (int)b.note_offset2);
+    #pragma message("velocity offset: uncomment this test when it's implemented")
+    // REQUIRE((int)a.midi_velocity_offset == (int)b.midi_velocity_offset);
+    REQUIRE((int)a.second_voice_detune == (int)b.second_voice_detune);
+    REQUIRE((int)a.percussion_key_number == (int)b.percussion_key_number);
+    REQUIRE((int)a.inst_flags == (int)b.inst_flags);
+    REQUIRE((int)a.fb_conn1_C0 == (int)b.fb_conn1_C0);
+    REQUIRE((int)a.fb_conn2_C0 == (int)b.fb_conn2_C0);
+    REQUIRE((int)a.delay_on_ms == (int)b.delay_on_ms);
+    REQUIRE((int)a.delay_off_ms == (int)b.delay_off_ms);
+    for (unsigned op = 0; op < 4; ++op) {
+        REQUIRE((int)a.operators[op].avekf_20 == (int)b.operators[op].avekf_20);
+        REQUIRE((int)a.operators[op].ksl_l_40 == (int)b.operators[op].ksl_l_40);
+        REQUIRE((int)a.operators[op].atdec_60 == (int)b.operators[op].atdec_60);
+        REQUIRE((int)a.operators[op].susrel_80 == (int)b.operators[op].susrel_80);
+        REQUIRE((int)a.operators[op].waveform_E0 == (int)b.operators[op].waveform_E0);
+    }
+}
+
+TEST_CASE("[Conversion] Main")
+{
+    rng.seed(777);
+
+    for (unsigned i = 0; i < 1000000; ++i) {
+        ADL_Instrument adl_ins = random_instrument();
+
+        adlinsdata2 internal_ins;
+        cvt_generic_to_FMIns(internal_ins, adl_ins);
+
+        ADL_Instrument adl_ins2;
+        cvt_FMIns_to_generic(adl_ins2, internal_ins);
+
+        check_instrument_equality(adl_ins, adl_ins2);
+    }
+}


### PR DESCRIPTION
Following your comment on 4op storage

This allows to keep operators 3-4 in program structures which are 2op.
This also eliminates the logic code which uses adlins comparisons for 2op checking and replaces with usage of flags.

I did a quick test.