### PR TITLE
add midi_velocity_offset in the conversion, and add unit test

### DIFF
--- a/src/adlmidi_cvt.hpp
+++ b/src/adlmidi_cvt.hpp
@@ -40,6 +40,7 @@ static void cvt_generic_to_FMIns(adlinsdata2 &ins, const WOPLI &in)
             ins.voice2_fine_tune = voice2_fine_tune * (15.625 / 1000.0);
     }
 
+    ins.midi_velocity_offset = in.midi_velocity_offset;
     ins.tone = in.percussion_key_number;
     ins.flags = (in.inst_flags & WOPL_Ins_4op) && (in.inst_flags & WOPL_Ins_Pseudo4op) ? adlinsdata::Flag_Pseudo4op : 0;
     ins.flags|= (in.inst_flags & WOPL_Ins_4op) && ((in.inst_flags & WOPL_Ins_Pseudo4op) == 0) ? adlinsdata::Flag_Real4op : 0;
@@ -93,6 +94,7 @@ static void cvt_FMIns_to_generic(WOPLI &ins, const adlinsdata2 &in)
         }
     }
 
+    ins.midi_velocity_offset = in.midi_velocity_offset;
     ins.percussion_key_number = in.tone;
     ins.inst_flags = (in.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? WOPL_Ins_4op : 0;
     ins.inst_flags|= (in.flags & adlinsdata::Flag_Pseudo4op) ? WOPL_Ins_Pseudo4op : 0;

--- a/test/conversion/conversion.cpp
+++ b/test/conversion/conversion.cpp
@@ -46,8 +46,7 @@ static void check_instrument_equality(const ADL_Instrument &a, const ADL_Instrum
 {
     REQUIRE((int)a.note_offset1 == (int)b.note_offset1);
     REQUIRE((int)a.note_offset2 == (int)b.note_offset2);
-    #pragma message("velocity offset: uncomment this test when it's implemented")
-    // REQUIRE((int)a.midi_velocity_offset == (int)b.midi_velocity_offset);
+    REQUIRE((int)a.midi_velocity_offset == (int)b.midi_velocity_offset);
     REQUIRE((int)a.second_voice_detune == (int)b.second_voice_detune);
     REQUIRE((int)a.percussion_key_number == (int)b.percussion_key_number);
     REQUIRE((int)a.inst_flags == (int)b.inst_flags);


### PR DESCRIPTION
There was a loss in the conflicting merge of the 2 last pulls, as conversions were moved to their own files for purposes of testing.
The midi velocity offset stopped being converted after that. This is the fix, and the matching update of unit test.
Since it's trivial and not much is to say of this fix, I'll merge it.