### PR TITLE
changing synth setup without the full MIDI reset

### DIFF
--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -114,7 +114,7 @@ ADLMIDI_EXPORT int adl_setNumChips(ADL_MIDIPlayer *device, int numChips)
     }
 
     play->m_synth.m_numChips = play->m_setup.numChips;
-    adl_reset(device);
+    play->partialReset();
 
     return adlRefreshNumCards(device);
 }
@@ -606,7 +606,7 @@ ADLMIDI_EXPORT int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulato
         if((emulator >= 0) && (emulator < ADLMIDI_EMU_end))
         {
             play->m_setup.emulator = emulator;
-            adl_reset(device);
+            play->partialReset();
             return 0;
         }
         play->setErrorString("OPL3 MIDI: Unknown emulation core!");
@@ -623,7 +623,7 @@ ADLMIDI_EXPORT int adl_setRunAtPcmRate(ADL_MIDIPlayer *device, int enabled)
         if(play)
         {
             play->m_setup.runAtPcmRate = (enabled != 0);
-            adl_reset(device);
+            play->partialReset();
             return 0;
         }
     }
@@ -670,11 +670,7 @@ ADLMIDI_EXPORT void adl_reset(struct ADL_MIDIPlayer *device)
     if(!device)
         return;
     MidiPlayer *play = GET_MIDI_PLAYER(device);
-    play->m_setup.tick_skip_samples_delay = 0;
-    play->m_synth.m_runAtPcmRate = play->m_setup.runAtPcmRate;
-    play->m_synth.reset(play->m_setup.emulator, play->m_setup.PCM_RATE, play);
-    play->m_chipChannels.clear();
-    play->m_chipChannels.resize((size_t)play->m_synth.m_numChannels);
+    play->partialReset();
     play->resetMIDI();
 }
 

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -205,6 +205,16 @@ void MIDIplay::applySetup()
     m_arpeggioCounter = 0;
 }
 
+void MIDIplay::partialReset()
+{
+    realTime_panic();
+    m_setup.tick_skip_samples_delay = 0;
+    m_synth.m_runAtPcmRate = m_setup.runAtPcmRate;
+    m_synth.reset(m_setup.emulator, m_setup.PCM_RATE, this);
+    m_chipChannels.clear();
+    m_chipChannels.resize((size_t)m_synth.m_numChannels);
+}
+
 void MIDIplay::resetMIDI()
 {
     m_masterVolume = MasterVolumeDefault;

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -488,6 +488,7 @@ public:
 
     void applySetup();
 
+    void partialReset();
     void resetMIDI();
 
     /**********************Internal structures and classes**********************/


### PR DESCRIPTION
#139

Attempt to fix an inability to conserve programs on changing chip count and others.
It returns ADLMIDI to an older behavior which my programs have relied on. (except `adl_reset` which remains as is)

It provides seamless transition when the setting of emulator or chip count is changed.
It's easy to observe the problem: pick any version of the VST after the big libADLMIDI update, change chip. The programs get reset.

What I do: replace full reset by basic reset, preceded by `realtime_panic` which stops current notes.