### PR TITLE
Implemented optional soft panning support.

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -365,6 +365,13 @@ extern void adl_setFullRangeBrightness(struct ADL_MIDIPlayer *device, int fr_bri
 extern void adl_setLoopEnabled(struct ADL_MIDIPlayer *device, int loopEn);
 
 /**
+ * @brief Enable or disable soft panning with chip emulators
+ * @param device Instance of the library
+ * @param softPanEn 0 - disabled, 1 - enabled
+ */
+extern void adl_setSoftPanEnabled(struct ADL_MIDIPlayer *device, int softPanEn);
+
+/**
  * @brief [DEPRECATED] Enable or disable Logarithmic volume changer
  *
  * This function is deprecated. Suggested replacement: `adl_setVolumeRangeModel` with `ADLMIDI_VolumeModel_NativeOPL3` volume model value;

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -447,6 +447,16 @@ ADLMIDI_EXPORT void adl_setLoopEnabled(ADL_MIDIPlayer *device, int loopEn)
 #endif
 }
 
+ADLMIDI_EXPORT void adl_setSoftPanEnabled(ADL_MIDIPlayer *device, int softPanEn)
+{
+    if (!device)
+        return;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    if (!play)
+        return;
+    play->m_synth.m_softPanning = softPanEn != 0;
+}
+
 /* !!!DEPRECATED!!! */
 ADLMIDI_EXPORT void adl_setLogarithmicVolumes(struct ADL_MIDIPlayer *device, int logvol)
 {

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -688,9 +688,7 @@ void MIDIplay::realTime_Controller(uint8_t channel, uint8_t type, uint8_t value)
         break;
 
     case 10: // Change panning
-        m_midiChannels[channel].panning = 0x00;
-        if(value  < 64 + 32) m_midiChannels[channel].panning |= OPL_PANNING_LEFT;
-        if(value >= 64 - 32) m_midiChannels[channel].panning |= OPL_PANNING_RIGHT;
+        m_midiChannels[channel].panning = value;
 
         noteUpdateAll(channel, Upd_Pan);
         break;

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -277,6 +277,8 @@ public:
     bool m_scaleModulators;
     //! Run emulator at PCM rate if that possible. Reduces sounding accuracy, but decreases CPU usage on lower rates.
     bool m_runAtPcmRate;
+    //! Enable soft panning
+    bool m_softPanning;
 
     //! Just a padding. Reserved.
     char _padding2[3];
@@ -379,6 +381,14 @@ public:
      * @param value Value to write
      */
     void writeRegI(size_t chip, uint32_t address, uint32_t value);
+
+    /**
+     * @brief Write to soft panning control of OPL3 chip emulator
+     * @param chip Index of emulated chip.
+     * @param address Register of channel to write
+     * @param value Value to write
+     */
+    void writePan(size_t chip, uint32_t address, uint32_t value);
 
     /**
      * @brief Off the note in specified chip channel

--- a/src/chips/dosbox/dbopl.h
+++ b/src/chips/dosbox/dbopl.h
@@ -192,6 +192,9 @@ struct Channel {
 	Bit8s maskLeft;		//Sign extended values for both channel's panning
 	Bit8s maskRight;
 
+	Bit16u panLeft; // Extended behavior, scale values for soft panning
+	Bit16u panRight;
+
 	//Forward the channel data to the operators of the channel
 	void SetChanData( const Chip* chip, Bit32u data );
 	//Change in the chandata, check for new values and if we have to forward to operators
@@ -200,6 +203,8 @@ struct Channel {
 	void WriteA0( const Chip* chip, Bit8u val );
 	void WriteB0( const Chip* chip, Bit8u val );
 	void WriteC0( const Chip* chip, Bit8u val );
+
+	void WritePan( Bit8u val );
 
 	//call this for the first channel
 	template< bool opl3Mode >
@@ -271,6 +276,7 @@ struct Chip {
 
 struct Handler {
 	DBOPL::Chip chip;
+	void WritePan( Bit32u port, Bit8u val );
 	Bit32u WriteAddr( Bit32u port, Bit8u val );
 	void WriteReg( Bit32u addr, Bit8u val );
 	void GenerateArr(Bit32s *out, Bitu *samples);

--- a/src/chips/dosbox_opl3.cpp
+++ b/src/chips/dosbox_opl3.cpp
@@ -61,6 +61,12 @@ void DosBoxOPL3::writeReg(uint16_t addr, uint8_t data)
     chip_r->WriteReg(static_cast<Bit32u>(addr), data);
 }
 
+void DosBoxOPL3::writePan(uint16_t addr, uint8_t data)
+{
+    DBOPL::Handler *chip_r = reinterpret_cast<DBOPL::Handler*>(m_chip);
+    chip_r->WritePan(static_cast<Bit32u>(addr), data);
+}
+
 void DosBoxOPL3::nativeGenerateN(int16_t *output, size_t frames)
 {
     DBOPL::Handler *chip_r = reinterpret_cast<DBOPL::Handler*>(m_chip);

--- a/src/chips/dosbox_opl3.h
+++ b/src/chips/dosbox_opl3.h
@@ -34,6 +34,7 @@ public:
     void setRate(uint32_t rate) override;
     void reset() override;
     void writeReg(uint16_t addr, uint8_t data) override;
+    void writePan(uint16_t addr, uint8_t data) override;
     void nativePreGenerate() override {}
     void nativePostGenerate() override {}
     void nativeGenerateN(int16_t *output, size_t frames) override;

--- a/src/chips/nuked/nukedopl3.h
+++ b/src/chips/nuked/nukedopl3.h
@@ -101,6 +101,7 @@ struct _opl3_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
+    Bit16u chl, chr;
     Bit8u ch_num;
 };
 
@@ -153,6 +154,7 @@ void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf);
 void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
 void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
+void OPL3_WritePan(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
 void OPL3_GenerateStreamMix(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
 

--- a/src/chips/nuked/nukedopl3_174.h
+++ b/src/chips/nuked/nukedopl3_174.h
@@ -103,6 +103,7 @@ struct _opl3_channel {
     Bit8u alg;
     Bit8u ksv;
     Bit16u cha, chb;
+    Bit16u chl, chr;
 };
 
 typedef struct _opl3_writebuf {
@@ -142,6 +143,7 @@ struct _opl3_chip {
 void OPL3v17_Generate(opl3_chip *chip, Bit16s *buf);
 void OPL3v17_GenerateResampled(opl3_chip *chip, Bit16s *buf);
 void OPL3v17_Reset(opl3_chip *chip, Bit32u samplerate);
+void OPL3v17_WritePan(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3v17_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3v17_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
 void OPL3v17_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);

--- a/src/chips/nuked_opl3.cpp
+++ b/src/chips/nuked_opl3.cpp
@@ -57,6 +57,12 @@ void NukedOPL3::writeReg(uint16_t addr, uint8_t data)
     OPL3_WriteRegBuffered(chip_r, addr, data);
 }
 
+void NukedOPL3::writePan(uint16_t addr, uint8_t data)
+{
+    opl3_chip *chip_r = reinterpret_cast<opl3_chip*>(m_chip);
+    OPL3_WritePan(chip_r, addr, data);
+}
+
 void NukedOPL3::nativeGenerate(int16_t *frame)
 {
     opl3_chip *chip_r = reinterpret_cast<opl3_chip*>(m_chip);

--- a/src/chips/nuked_opl3.h
+++ b/src/chips/nuked_opl3.h
@@ -34,6 +34,7 @@ public:
     void setRate(uint32_t rate) override;
     void reset() override;
     void writeReg(uint16_t addr, uint8_t data) override;
+    void writePan(uint16_t addr, uint8_t data) override;
     void nativePreGenerate() override {}
     void nativePostGenerate() override {}
     void nativeGenerate(int16_t *frame) override;

--- a/src/chips/nuked_opl3_v174.cpp
+++ b/src/chips/nuked_opl3_v174.cpp
@@ -57,6 +57,12 @@ void NukedOPL3v174::writeReg(uint16_t addr, uint8_t data)
     OPL3v17_WriteReg(chip_r, addr, data);
 }
 
+void NukedOPL3v174::writePan(uint16_t addr, uint8_t data)
+{
+    opl3_chip *chip_r = reinterpret_cast<opl3_chip*>(m_chip);
+    OPL3v17_WritePan(chip_r, addr, data);
+}
+
 void NukedOPL3v174::nativeGenerate(int16_t *frame)
 {
     opl3_chip *chip_r = reinterpret_cast<opl3_chip*>(m_chip);

--- a/src/chips/nuked_opl3_v174.h
+++ b/src/chips/nuked_opl3_v174.h
@@ -34,6 +34,7 @@ public:
     void setRate(uint32_t rate) override;
     void reset() override;
     void writeReg(uint16_t addr, uint8_t data) override;
+    void writePan(uint16_t addr, uint8_t data) override;
     void nativePreGenerate() override {}
     void nativePostGenerate() override {}
     void nativeGenerate(int16_t *frame) override;

--- a/src/chips/opl_chip_base.h
+++ b/src/chips/opl_chip_base.h
@@ -61,6 +61,9 @@ public:
     virtual void reset() = 0;
     virtual void writeReg(uint16_t addr, uint8_t data) = 0;
 
+    // extended
+    virtual void writePan(uint16_t addr, uint8_t data) { };
+
     virtual void nativePreGenerate() = 0;
     virtual void nativePostGenerate() = 0;
     virtual void nativeGenerate(int16_t *frame) = 0;


### PR DESCRIPTION
Implementation extends to the three bundled chip emulators, and is dummied by default, since we don't want to do anything when running against hardware implementations.