### PR TITLE
fix some warnings

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -125,7 +125,7 @@ enum ADLMIDI_SampleType
     /*! unsigned PCM 32-bit */
     ADLMIDI_SampleType_U32,
     /*! Count of available sample format types */
-    ADLMIDI_SampleType_Count,
+    ADLMIDI_SampleType_Count
 };
 
 /**
@@ -220,7 +220,7 @@ enum ADL_BankAccessFlags
     /*! create bank, allocating memory as needed */
     ADLMIDI_Bank_Create = 1,
     /*! create bank, never allocating memory */
-    ADLMIDI_Bank_CreateRt = 1|2,
+    ADLMIDI_Bank_CreateRt = 1|2
 };
 
 typedef struct ADL_Instrument ADL_Instrument;
@@ -672,7 +672,7 @@ enum ADLMIDI_TrackOptions
     /*! Disabled track */
     ADLMIDI_TrackOption_Off  = 2,
     /*! Solo track */
-    ADLMIDI_TrackOption_Solo = 3,
+    ADLMIDI_TrackOption_Solo = 3
 };
 
 /**
@@ -1073,7 +1073,7 @@ extern ADLMIDI_DECLSPEC int adl_describeChannels(struct ADL_MIDIPlayer *device, 
  */
 enum
 {
-    ADLMIDI_InstrumentVersion = 0,
+    ADLMIDI_InstrumentVersion = 0
 };
 
 /**
@@ -1094,7 +1094,7 @@ typedef enum ADL_InstrumentFlags
     ADLMIDI_Ins_RhythmModeMask = 0x38,
 
     /*! Mask of the flags range */
-    ADLMIDI_Ins_ALL_MASK   = 0x07,
+    ADLMIDI_Ins_ALL_MASK   = 0x07
 } ADL_InstrumentFlags;
 
 /**

--- a/src/adlmidi_bankmap.h
+++ b/src/adlmidi_bankmap.h
@@ -74,7 +74,7 @@ private:
     enum
     {
         hash_bits = 8, /* worst case # of collisions: 128^2/2^hash_bits */
-        hash_buckets = 1 << hash_bits,
+        hash_buckets = 1 << hash_bits
     };
 
 public:

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -601,7 +601,7 @@ public:
             enum
             {
                 MaxNumPhysChans = 2,
-                MaxNumPhysItemCount = MaxNumPhysChans,
+                MaxNumPhysItemCount = MaxNumPhysChans
             };
 
             /**
@@ -858,7 +858,7 @@ public:
                 Sustain_None        = 0x00,
                 Sustain_Pedal       = 0x01,
                 Sustain_Sostenuto   = 0x02,
-                Sustain_ANY         = Sustain_Pedal | Sustain_Sostenuto,
+                Sustain_ANY         = Sustain_Pedal | Sustain_Sostenuto
             };
             uint32_t sustained;
             char _padding[6];
@@ -999,7 +999,7 @@ public:
         Mode_GM  = 0x00,
         Mode_GS  = 0x01,
         Mode_XG  = 0x02,
-        Mode_GM2 = 0x04,
+        Mode_GM2 = 0x04
     };
     //! MIDI Synthesizer mode
     uint32_t m_synthMode;

--- a/src/chips/dosbox/dbopl.cpp
+++ b/src/chips/dosbox/dbopl.cpp
@@ -465,6 +465,7 @@ Bits Operator::TemplateVolume(  ) {
 			return vol;
 		}
 		//In sustain phase, but not sustaining, do regular release
+                /* fall through */
 	case RELEASE:
 		vol += RateForward( releaseAdd );;
 		if ( GCC_UNLIKELY(vol >= ENV_MAX) ) {

--- a/src/chips/dosbox/dbopl.h
+++ b/src/chips/dosbox/dbopl.h
@@ -75,13 +75,13 @@ typedef enum {
 	sm3AMAM,
 	sm6Start,
 	sm2Percussion,
-	sm3Percussion,
+	sm3Percussion
 } SynthMode;
 
 //Shifts for the values contained in chandata variable
 enum {
 	SHIFT_KSLBASE = 16,
-	SHIFT_KEYCODE = 24,
+	SHIFT_KEYCODE = 24
 };
 
 struct Operator {
@@ -91,7 +91,7 @@ public:
 		MASK_KSR = 0x10,
 		MASK_SUSTAIN = 0x20,
 		MASK_VIBRATO = 0x40,
-		MASK_TREMOLO = 0x80,
+		MASK_TREMOLO = 0x80
 	};
 
 	typedef enum {
@@ -99,7 +99,7 @@ public:
 		RELEASE,
 		SUSTAIN,
 		DECAY,
-		ATTACK,
+		ATTACK
 	} State;
 
 	VolumeHandler volHandler;

--- a/src/midi_sequencer.hpp
+++ b/src/midi_sequencer.hpp
@@ -132,7 +132,7 @@ class BW_MidiSequencer
             //! [Non-Standard] Loop End point with support of multi-loops
             ST_LOOPSTACK_BREAK = 0xE6,//size == 0 <CUSTOM>
             //! [Non-Standard] Callback Trigger
-            ST_CALLBACK_TRIGGER = 0xE7,//size == 1 <CUSTOM>
+            ST_CALLBACK_TRIGGER = 0xE7//size == 1 <CUSTOM>
         };
         //! Main type of event
         uint8_t type;

--- a/utils/adlmidi-2/puzzlegame.cc
+++ b/utils/adlmidi-2/puzzlegame.cc
@@ -90,7 +90,7 @@ bool ADLMIDI_PuzzleGame::TetrisArea::CascadeEmpty(int FirstY)
                  * FIXME: Improve weird code fragment disliked by CLang
                  * /////////BEGIN////////////
                  */
-                auto label =
+                auto label = &
                     "  SINGLE  "
                     "  DOUBLE  "
                     "  TRIPLE  "
@@ -100,7 +100,7 @@ bool ADLMIDI_PuzzleGame::TetrisArea::CascadeEmpty(int FirstY)
                     " SEXTUPLE "
                     " SEPTUPLE "
                     " OCTUPLE  "
-                    + ((n_full - 1) * 10);
+                    [(n_full - 1) * 10];
                 for(int y = FirstY; y < Height - 1; ++y)
                 {
                     if(list_full & (1u << y))
@@ -214,9 +214,9 @@ int ADLMIDI_PuzzleGame::TetrisAIengine::AI_Run(const decltype(Area)&in_area, con
             for(unsigned rot2 = 0; rot2 < 4; ++rot2)
                 for(int x2 = -1; x2 <= 1; ++x2)
                 {
-                    positions1.push_back(std::move<position> ({int(rot), x, int(rot2), x2}));
+                    positions1.push_back(position{int(rot), x, int(rot2), x2});
                     if(rot2 == rot && x2 == 0)
-                        positions2.push_back(std::move<position> ({int(rot), x, int(rot2), x2}));
+                        positions2.push_back(position{int(rot), x, int(rot2), x2});
                 }
 
     confident = false;


### PR DESCRIPTION
Fixed GCC Warnings

- warning: this statement may fall through [-Wimplicit-fallthrough=]

Fixed Clang Warnings:

- warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
- warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
- warning: commas at the end of enumerator lists are a C++11 extension [-Wc++11-extensions]

Warnings present still not fixed:

- warning: variadic macros are a C99 feature [-Wvariadic-macros]
- warning: anonymous variadic macros were introduced in C++11 [-Wvariadic-macros]
- warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct adlinsdata2'; use assignment or value-initialization instead [-Wclass-memaccess]
- warning: 'strncpy' output may be truncated copying 32 bytes from a string of length 33 [-Wstringop-truncation]