### PR TITLE
fix the gcc warning "class-memaccess"

### DIFF
--- a/src/adldata.hh
+++ b/src/adldata.hh
@@ -76,8 +76,7 @@ struct adlinsdata2
     uint16_t    ms_sound_koff;
     int8_t      midi_velocity_offset;
     double      voice2_fine_tune;
-    adlinsdata2() {}
-    explicit adlinsdata2(const adlinsdata &d);
+    static adlinsdata2 from_adldata(const adlinsdata &d);
 };
 ADLDATA_BYTE_COMPARABLE(struct adlinsdata2)
 
@@ -108,17 +107,22 @@ extern const AdlBankSetup adlbanksetup[];
 /**
  * @brief Conversion of storage formats
  */
-inline adlinsdata2::adlinsdata2(const adlinsdata &d)
-    : tone(d.tone), flags(d.flags),
-      ms_sound_kon(d.ms_sound_kon), ms_sound_koff(d.ms_sound_koff),
-      midi_velocity_offset(d.midi_velocity_offset), voice2_fine_tune(d.voice2_fine_tune)
+inline adlinsdata2 adlinsdata2::from_adldata(const adlinsdata &d)
 {
+    adlinsdata2 ins;
+    ins.tone = d.tone;
+    ins.flags = d.flags;
+    ins.ms_sound_kon = d.ms_sound_kon;
+    ins.ms_sound_koff = d.ms_sound_koff;
+    ins.midi_velocity_offset = d.midi_velocity_offset;
+    ins.voice2_fine_tune = d.voice2_fine_tune;
 #ifdef DISABLE_EMBEDDED_BANKS
-    std::memset(adl, 0, sizeof(adldata) * 2);
+    std::memset(ins.adl, 0, sizeof(adldata) * 2);
 #else
-    adl[0] = ::adl[d.adlno1];
-    adl[1] = ::adl[d.adlno2];
+    ins.adl[0] = ::adl[d.adlno1];
+    ins.adl[1] = ::adl[d.adlno2];
 #endif
+    return ins;
 }
 
 /**

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -341,7 +341,7 @@ ADLMIDI_EXPORT int adl_loadEmbeddedBank(struct ADL_MIDIPlayer *device, ADL_Bank 
     for (unsigned i = 0; i < 128; ++i) {
         size_t insno = i + ((id & OPL3::PercussionTag) ? 128 : 0);
         size_t adlmeta = ::banks[num][insno];
-        it->second.ins[i] = adlinsdata2(::adlins[adlmeta]);
+        it->second.ins[i] = adlinsdata2::from_adldata(::adlins[adlmeta]);
     }
     return 0;
 #endif

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1877,7 +1877,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::DoNote(int note)
     OPL3 *opl = P->opl;
     if(P->adl_ins_list.empty()) FindAdlList();
     const unsigned meta = P->adl_ins_list[P->ins_idx];
-    const adlinsdata2 ains(adlins[meta]);
+    const adlinsdata2 ains = adlinsdata2::from_adldata(::adlins[meta]);
 
     int tone = (P->cur_gm & 128) ? (P->cur_gm & 127) : (note + 50);
     if(ains.tone)
@@ -1959,7 +1959,7 @@ ADLMIDI_EXPORT void AdlInstrumentTester::NextAdl(int offset)
     for(size_t a = 0, n = P->adl_ins_list.size(); a < n; ++a)
     {
         const unsigned i = P->adl_ins_list[a];
-        const adlinsdata2 ains(adlins[i]);
+        const adlinsdata2 ains = adlinsdata2::from_adldata(::adlins[i]);
 
         char ToneIndication[8] = "   ";
         if(ains.tone)

--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -153,7 +153,7 @@ void OPL3::setEmbeddedBank(uint32_t bank)
     {
         size_t meta = banks[bank][i];
         adlinsdata2 &ins = bank_pair[i / 128]->ins[i % 128];
-        ins = adlinsdata2(adlins[meta]);
+        ins = adlinsdata2::from_adldata(::adlins[meta]);
     }
 #else
     ADL_UNUSED(bank);

--- a/src/adlmidi_private.cpp
+++ b/src/adlmidi_private.cpp
@@ -72,7 +72,7 @@ int adlRefreshNumCards(ADL_MIDIPlayer *device)
             if(insno == 198)
                 continue;
             ++n_total[a / 128];
-            adlinsdata2 ins(adlins[insno]);
+            adlinsdata2 ins = adlinsdata2::from_adldata(::adlins[insno]);
             if((ins.flags & adlinsdata::Flag_Real4op) != 0)
                 ++n_fourop[a / 128];
         }


### PR DESCRIPTION
This allows `adlinsdata2` to be a trivial type.

Fixes:
`warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'struct adlinsdata2'; use assignment or value-initialization instead [-Wclass-memaccess]`
