### PR TITLE
add safety check for emulator switching

### DIFF
--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -613,7 +613,7 @@ ADLMIDI_EXPORT int adl_switchEmulator(struct ADL_MIDIPlayer *device, int emulato
         assert(play);
         if(!play)
             return -1;
-        if((emulator >= 0) && (emulator < ADLMIDI_EMU_end))
+        if(adl_isEmulatorAvailable(emulator))
         {
             play->m_setup.emulator = emulator;
             play->partialReset();

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -129,7 +129,7 @@ MIDIplay::MIDIplay(unsigned long sampleRate):
 {
     m_midiDevices.clear();
 
-    m_setup.emulator = ADLMIDI_EMU_NUKED;
+    m_setup.emulator = adl_getLowestEmulator();
     m_setup.runAtPcmRate = false;
 
     m_setup.PCM_RATE   = sampleRate;

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -1472,5 +1472,8 @@ extern void adl_audioTickHandler(void *instance, uint32_t chipId, uint32_t rate)
 #endif
 extern int adlRefreshNumCards(ADL_MIDIPlayer *device);
 
+extern bool adl_isEmulatorAvailable(int emulator);
+extern int adl_getHighestEmulator();
+extern int adl_getLowestEmulator();
 
 #endif // ADLMIDI_PRIVATE_HPP


### PR DESCRIPTION
Verification of presence of an emulator passed to `switchEmulator`.
It's a step to allow for a more robust scanning, but especially when some of the emulators will be disabled.
Usually, libADMIDI would be happy to answer OK for a disabled emulator id and default to the first enabled other in that case.