### PR TITLE
early koff update to prevent a bad reuse of channel

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -578,6 +578,15 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
     }
 
     noteUpdate(channel, ir.first, Upd_All | Upd_Patch);
+
+    for(unsigned ccount = 0; ccount < MIDIchannel::NoteInfo::MaxNumPhysChans; ++ccount)
+    {
+        int32_t c = adlchannel[ccount];
+        if(c < 0)
+            continue;
+        m_chipChannels[c].addAge(0);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
#154 
I have thought of a simple attempt to fix arpeggio issues. It's not tested. :warning: 

It would force an update of timing just at the end of note-on, and before a second note-on which would arrive without having `TickIterators` happened between.
In such a way, it's become possible that a taken channel can reinitialize its `koff` time before a case of note-on coming right after.
In such a way, it could fix the scoring of a next channel selection, which could happen to reselect the already taken channel if the `koff` time outweighs the 4000 point malus for each arpeggio user already on channel.

Do you think of it as correct reasoning?