### PR TITLE
XMI: fix the VLQ reading procedure

### DIFF
--- a/src/cvt_xmi2mid.hpp
+++ b/src/cvt_xmi2mid.hpp
@@ -640,7 +640,7 @@ static int xmi2mid_GetVLQ2(struct xmi2mid_xmi_ctx *ctx, uint32_t *quant) {
     int32_t data;
 
     *quant = 0;
-    for (i = 0; i < 4; i++) {
+    for (i = 0; xmi2mid_getsrcpos(ctx) != xmi2mid_getsrcsize(ctx); ++i) {
         data = xmi2mid_read1(ctx);
         if (data & 0x80) {
             xmi2mid_skipsrc(ctx, -1);


### PR DESCRIPTION
This fixes how Warcraft II's tail events are read by XMI's parser.

As a difference with SMF format, XMI reads its delta by summing the continuation bytes, instead of concatenating the bits. (not a very smart way of proceeding when you think of it)

Problem with WildMidi's parser: it forces to stop at the 4th byte.
In this case, the delta is not allowed to exceed the value 4*127=508.
Which is why if you trace Wc2's XMI parsing, you'll see lots of 508s in a sequence, and of course incorrect event data following.

As a fix, I allow it to accumulate its delta without a bounds for the count of bytes read.

**Note**: this doesn't fix the big delta at end of file, which results in very long playback time.
The sequencer must receive its own workaround for this other problem.

Gotta report this fix back at the WildMidi devs also.