### PR TITLE
API to return 4op channels to the original count

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -329,6 +329,7 @@ extern ADLMIDI_DECLSPEC int adl_loadEmbeddedBank(struct ADL_MIDIPlayer *device, 
  * If you want to specify custom number of four operator channels,
  * please call this function after bank change (adl_setBank() or adl_openBank()),
  * otherwise, value will be overwritten by auto-calculated.
+ * If the count is specified as -1, an auto-calculated amount is used instead.
  *
  * @param device Instance of the library
  * @param ops4 Count of four-op channels to allocate between all emulating chips

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -351,6 +351,10 @@ ADLMIDI_EXPORT int adl_setNumFourOpsChn(ADL_MIDIPlayer *device, int ops4)
 {
     if(!device)
         return -1;
+
+    if(ops4 == -1)
+        return adlRefreshNumCards(device);
+
     MidiPlayer *play = GET_MIDI_PLAYER(device);
     if((unsigned int)ops4 > 6 * play->m_setup.numChips)
     {
@@ -364,7 +368,7 @@ ADLMIDI_EXPORT int adl_setNumFourOpsChn(ADL_MIDIPlayer *device, int ops4)
     play->m_synth.m_numFourOps = play->m_setup.numFourOps;
     play->m_synth.updateChannelCategories();
 
-    return 0; //adlRefreshNumCards(device);
+    return 0;
 }
 
 ADLMIDI_EXPORT int adl_getNumFourOpsChn(struct ADL_MIDIPlayer *device)


### PR DESCRIPTION
Do you agree with such ability to return 4op count to the calculated value?
From the plugin, I am invoking `adlRefreshNumCards` and it's a big hack, because I don't seem to have another possibility at disposal.
