### PR TITLE
fix a case of miscalculation and infinite loop

### DIFF
--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -1599,7 +1599,7 @@ void MIDIplay::setRPN(size_t midCh, unsigned value, bool MSB)
     case 0x0109 + 1*0x10000 + 1*0x20000:
         if((m_synthMode & Mode_XG) != 0) // Vibrato depth
         {
-            m_midiChannels[midCh].vibdepth = ((value - 64) * 0.15) * 0.01;
+            m_midiChannels[midCh].vibdepth = (((int)value - 64) * 0.15) * 0.01;
         }
         break;
     case 0x010A + 1*0x10000 + 1*0x20000:


### PR DESCRIPTION
Important bug fix :warning: 

This solves a problem of execution getting stuck in sound processing.
In following vibrato depth calculation, the value is typed as unsigned, and creates an expression result as a very large integer. This large integer gets into the frequency calculation formula and creates an infinity result. It puts the program in a situation of infinite loop at OPL3::noteOn.