### PR TITLE
fix a miswritten name: sneakernets

### DIFF
--- a/banks.ini
+++ b/banks.ini
@@ -532,7 +532,7 @@ name     = "WOPL (DMXOPL3 bank by Sneakernets)"
 ; file     = "fm_banks/doom2/DMXOPL-by-sneakernets.op2"
 format   = WOPL
 file     = "fm_banks/wopl_files/DMXOPL3-by-sneakernets-GS.wopl"
-prefix   = "skeakernets"
+prefix   = "sneakernets"
 
 ; Special bank required to play MUS-files from Cartooners game
 [bank-73]

--- a/utils/gen_adldata/scrapped.txt
+++ b/utils/gen_adldata/scrapped.txt
@@ -254,7 +254,7 @@ LoadTMB("fm_banks/tmb_files/bloodtmb.tmb",  69, "apgblood");
 LoadTMB("fm_banks/tmb_files/lee.tmb",  70, "apglee");
 LoadTMB("fm_banks/tmb_files/nam.tmb",  71, "apgnam");
 
-LoadDoom("fm_banks/doom2/DMXOPL-by-sneakernets.op2", 72, "skeakernets");
+LoadDoom("fm_banks/doom2/DMXOPL-by-sneakernets.op2", 72, "sneakernets");
 
 //LoadBNK("bnk_files/grassman1.bnk", 63, "b63", false);
 //LoadBNK("bnk_files/grassman2.bnk", 64, "b64", false);


### PR DESCRIPTION
Found another small error in metadata.
This one, it's just in prefix which I don't know what its usage is. Adldata seems unaffected.