### PR TITLE
provide default initialization for bank setup

### DIFF
--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -168,6 +168,12 @@ OPL3::OPL3() :
     m_musicMode(MODE_MIDI),
     m_volumeScale(VOLUME_Generic)
 {
+    m_insBankSetup.volumeModel = OPL3::VOLUME_Generic;
+    m_insBankSetup.deepTremolo = false;
+    m_insBankSetup.deepVibrato = false;
+    m_insBankSetup.adLibPercussions = false;
+    m_insBankSetup.scaleModulators = false;
+
 #ifdef DISABLE_EMBEDDED_BANKS
     m_embeddedBank = CustomBankTag;
 #else


### PR DESCRIPTION
Fixes an uninitialized use which is difficult to track.

With embedded bank disabled, the bank setup never initializes the value at `adl_init`, which depends on values for channels setup as rhythm mode or not, and also modulator scaling to invoke codes which silence all notes.