### PR TITLE
rename DOSBox using preferred casing

### DIFF
--- a/src/chips/dosbox_opl3.cpp
+++ b/src/chips/dosbox_opl3.cpp
@@ -76,5 +76,5 @@ void DosBoxOPL3::nativeGenerateN(int16_t *output, size_t frames)
 
 const char *DosBoxOPL3::emulatorName()
 {
-    return "DosBox 0.74-r4111 OPL3";
+    return "DOSBox 0.74-r4111 OPL3";
 }

--- a/utils/vlc_codec/libadlmidi.c
+++ b/utils/vlc_codec/libadlmidi.c
@@ -98,7 +98,7 @@ static const char * const emulator_type_descriptions[] =
 {
     N_("Nuked OPL3 1.8"),
     N_("Nuked OPL3 1.7.4 (Optimized)"),
-    N_("DosBox"),
+    N_("DOSBox"),
     NULL
 };
 


### PR DESCRIPTION
Rename DOSBox from a previous naming "DosBox".
It's the preferred way of writing from most of places where seen.
