### PR TITLE
access into global chip settings

### DIFF
--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -362,11 +362,25 @@ extern ADLMIDI_DECLSPEC void adl_setPercMode(struct ADL_MIDIPlayer *device, int 
 extern ADLMIDI_DECLSPEC void adl_setHVibrato(struct ADL_MIDIPlayer *device, int hvibro);
 
 /**
+ * @brief Get the deep vibrato state.
+ * @param device Instance of the library
+ * @return deep vibrato state on success, <0 when any error has occurred
+ */
+extern ADLMIDI_DECLSPEC int adl_getHVibrato(struct ADL_MIDIPlayer *device);
+
+/**
  * @brief Override Enable(1) or Disable(0) deep tremolo state. -1 - use bank default tremolo state
  * @param device Instance of the library
  * @param htremo 0 - disabled, 1 - enabled
  */
 extern ADLMIDI_DECLSPEC void adl_setHTremolo(struct ADL_MIDIPlayer *device, int htremo);
+
+/**
+ * @brief Get the deep tremolo state.
+ * @param device Instance of the library
+ * @return deep tremolo state on success, <0 when any error has occurred
+ */
+extern ADLMIDI_DECLSPEC int adl_getHTremolo(struct ADL_MIDIPlayer *device);
 
 /**
  * @brief Override Enable(1) or Disable(0) scaling of modulator volumes. -1 - use bank default scaling of modulator volumes
@@ -414,6 +428,13 @@ extern ADLMIDI_DECLSPEC void adl_setLogarithmicVolumes(struct ADL_MIDIPlayer *de
  * @param volumeModel Volume model type (#ADLMIDI_VolumeModels)
  */
 extern ADLMIDI_DECLSPEC void adl_setVolumeRangeModel(struct ADL_MIDIPlayer *device, int volumeModel);
+
+/**
+ * @brief Get the volume range model
+ * @param device Instance of the library
+ * @return volume model on success, <0 when any error has occurred
+ */
+extern ADLMIDI_DECLSPEC int adl_getVolumeRangeModel(struct ADL_MIDIPlayer *device);
 
 /**
  * @brief Load WOPL bank file from File System

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -403,6 +403,13 @@ ADLMIDI_EXPORT void adl_setHVibrato(ADL_MIDIPlayer *device, int hvibro)
     play->m_synth.commitDeepFlags();
 }
 
+ADLMIDI_EXPORT int adl_getHVibrato(struct ADL_MIDIPlayer *device)
+{
+    if(!device) return -1;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    return play->m_synth.m_deepVibratoMode;
+}
+
 ADLMIDI_EXPORT void adl_setHTremolo(ADL_MIDIPlayer *device, int htremo)
 {
     if(!device) return;
@@ -412,6 +419,13 @@ ADLMIDI_EXPORT void adl_setHTremolo(ADL_MIDIPlayer *device, int htremo)
                                     play->m_synth.m_insBankSetup.deepTremolo :
                                     (play->m_setup.deepTremoloMode != 0);
     play->m_synth.commitDeepFlags();
+}
+
+ADLMIDI_EXPORT int adl_getHTremolo(struct ADL_MIDIPlayer *device)
+{
+    if(!device) return -1;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    return play->m_synth.m_deepTremoloMode;
 }
 
 ADLMIDI_EXPORT void adl_setScaleModulators(ADL_MIDIPlayer *device, int smod)
@@ -488,6 +502,16 @@ ADLMIDI_EXPORT void adl_setVolumeRangeModel(struct ADL_MIDIPlayer *device, int v
         play->m_synth.m_volumeScale = (OPL3::VolumesScale)play->m_synth.m_insBankSetup.volumeModel;
     else
         play->m_synth.setVolumeScaleModel(static_cast<ADLMIDI_VolumeModels>(volumeModel));
+}
+
+ADLMIDI_EXPORT int adl_getVolumeRangeModel(struct ADL_MIDIPlayer *device)
+{
+    if(!device)
+        return -1;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    if(!play)
+        return -1;
+    return play->m_synth.getVolumeScaleModel();
 }
 
 ADLMIDI_EXPORT int adl_openBankFile(struct ADL_MIDIPlayer *device, const char *filePath)

--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -631,6 +631,24 @@ void OPL3::setVolumeScaleModel(ADLMIDI_VolumeModels volumeModel)
     }
 }
 
+ADLMIDI_VolumeModels OPL3::getVolumeScaleModel()
+{
+    switch(m_volumeScale)
+    {
+    default:
+    case OPL3::VOLUME_Generic:
+        return ADLMIDI_VolumeModel_Generic;
+    case OPL3::VOLUME_NATIVE:
+        return ADLMIDI_VolumeModel_NativeOPL3;
+    case OPL3::VOLUME_DMX:
+        return ADLMIDI_VolumeModel_DMX;
+    case OPL3::VOLUME_APOGEE:
+        return ADLMIDI_VolumeModel_APOGEE;
+    case OPL3::VOLUME_9X:
+        return ADLMIDI_VolumeModel_9X;
+    }
+}
+
 #ifndef ADLMIDI_HW_OPL
 void OPL3::clearChips()
 {

--- a/src/adlmidi_private.hpp
+++ b/src/adlmidi_private.hpp
@@ -448,6 +448,11 @@ public:
      */
     void setVolumeScaleModel(ADLMIDI_VolumeModels volumeModel);
 
+    /**
+     * @brief Get the volume scaling model
+     */
+    ADLMIDI_VolumeModels getVolumeScaleModel();
+
     #ifndef ADLMIDI_HW_OPL
     /**
      * @brief Clean up all running emulated chip instances


### PR DESCRIPTION
Add some functions to be able to track chip's global state which is current: tremolo flags, volume model.