### PR TITLE
eliminate a redundant null check

### DIFF
--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -659,12 +659,9 @@ ADLMIDI_EXPORT int adl_setRunAtPcmRate(ADL_MIDIPlayer *device, int enabled)
     {
         MidiPlayer *play = GET_MIDI_PLAYER(device);
         assert(play);
-        if(play)
-        {
-            play->m_setup.runAtPcmRate = (enabled != 0);
-            play->partialReset();
-            return 0;
-        }
+        play->m_setup.runAtPcmRate = (enabled != 0);
+        play->partialReset();
+        return 0;
     }
     return -1;
 }


### PR DESCRIPTION
Removing a redundant null check remaining I have just noticed.