### PR TITLE
fix minute display on 1+ hour tracks

### DIFF
--- a/utils/midiplay/adlmidiplay.cpp
+++ b/utils/midiplay/adlmidiplay.cpp
@@ -210,10 +210,10 @@ static inline void secondsToHMSM(double seconds_full, char *hmsm_buffer, size_t 
 {
     double seconds_integral;
     double seconds_fractional = std::modf(seconds_full, &seconds_integral);
-    unsigned int milliseconds = static_cast<unsigned int>(std::floor(seconds_fractional * 1000.0));
+    unsigned int milliseconds = static_cast<unsigned int>(seconds_fractional * 1000.0);
     unsigned int seconds = static_cast<unsigned int>(std::fmod(seconds_full, 60.0));
-    unsigned int minutes = static_cast<unsigned int>(std::floor(seconds_full / 60));
-    unsigned int hours   = static_cast<unsigned int>(std::floor(seconds_full / 3600));
+    unsigned int minutes = static_cast<unsigned int>(std::fmod(seconds_full / 60, 60.0));
+    unsigned int hours   = static_cast<unsigned int>(seconds_full / 3600);
     std::memset(hmsm_buffer, 0, hmsm_buffer_size);
     if (hours > 0)
         snprintf(hmsm_buffer, hmsm_buffer_size, "%02u:%02u:%02u,%03u", hours, minutes, seconds, milliseconds);


### PR DESCRIPTION
Add a call `fmod` to fix the minutes. Also remove the `floor` calls redundant because of casts.

MIDI file for test [thrust.mid.gz](https://github.com/Wohlstand/libADLMIDI/files/2568453/thrust.mid.gz)

before `11:673:58,221`
after `11:13:58,221`
