### PR TITLE
opal: fix the computation of KSL

### DIFF
--- a/src/chips/opal/opal.hpp
+++ b/src/chips/opal/opal.hpp
@@ -1237,12 +1237,9 @@ void Opal::Operator::SetFrequencyMultiplier(uint16_t scale) {
 //==================================================================================================
 void Opal::Operator::SetKeyScale(uint16_t scale) {
 
-    if (scale > 0)
-        KeyScaleShift = 3 - scale;
-
-    // No scaling, ensure it has no effect
-    else
-        KeyScaleShift = 15;
+    /* libADLMIDI: KSL computation fix */
+    const unsigned KeyScaleShiftTable[4] = {8, 1, 2, 0};
+    KeyScaleShift = KeyScaleShiftTable[scale];
 
     ComputeKeyScaleLevel();
 }


### PR DESCRIPTION
This fixes the KSL computation of Opal which is incorrect.

From YMF262 docs: some values are in unnatural order, which make it misleading.

KSL | 0 | 1 | 2 | 3
|---|---|---|---|---|
Attenuation | 0 | 3 dB/oct | 1.5 dB/oct | 6 dB/oct