### PR TITLE
Bugfix

### DIFF
--- a/src/chips/java/JavaOPL3.hpp
+++ b/src/chips/java/JavaOPL3.hpp
@@ -1641,6 +1641,8 @@ double TopCymbalOperator::getOperatorOutput(OPL3 *OPL3, double modulator) {
 // Conversely, this method is also used through inheritance by the HighHatOperator, 
 // now with the TopCymbalOperator phase as the externalPhase.
 double TopCymbalOperator::getOperatorOutput(OPL3 *OPL3, double modulator, double externalPhase) {
+	(void)modulator;
+
 	double envelopeInDB = envelopeGenerator.getEnvelope(OPL3, egt, am);
 	envelope = EnvelopeFromDB(envelopeInDB);
 	
@@ -1661,8 +1663,6 @@ double TopCymbalOperator::getOperatorOutput(OPL3 *OPL3, double modulator, double
 	if( chopped > 0.1) carrierOutput = 0;
 	
 	return carrierOutput*2;  
-
-	(void)modulator;
 }
 
 HighHatOperator::HighHatOperator()

--- a/src/chips/java/JavaOPL3.hpp
+++ b/src/chips/java/JavaOPL3.hpp
@@ -1002,7 +1002,7 @@ static double EnvelopeFromDB(double db)
 
 Channel::Channel (int baseAddress, double startvol) {
 	channelBaseAddress = baseAddress;
-	fnuml = fnumh = kon = block = fb = cnt = 0;
+	fnuml = fnumh = kon = block = fb = cha = chb = cnt = 0;
 	feedback[0] = feedback[1] = 0;
 	leftPan = rightPan = startvol;
 }

--- a/src/chips/java/JavaOPL3.hpp
+++ b/src/chips/java/JavaOPL3.hpp
@@ -1230,7 +1230,7 @@ const double Operator::noModulator = 0;
 Operator::Operator(int baseAddress) {
 	operatorBaseAddress = baseAddress;
 
-	envelope = 0;
+	envelope = phase = 0;
 	am = vib = ksr = egt = mult = ksl = tl = ar = dr = sl = rr = ws = 0;
 	keyScaleNumber = f_number = block = 0;
 }

--- a/src/chips/opal/opal.hpp
+++ b/src/chips/opal/opal.hpp
@@ -329,6 +329,7 @@ void Opal::Init(int sample_rate) {
 
     Clock = 0;
     TremoloClock = 0;
+    TremoloLevel = 0;
     VibratoTick = 0;
     VibratoClock = 0;
     NoteSel = false;


### PR DESCRIPTION
Fix a few coverity warnings (not all)

missing : Opal uninitialized, Opal bit shift in wavegen
the bit shift warning does not seem to make sense, it takes the output sample as if constant at the max level.