### PR TITLE
Update emulators enabled check

### DIFF
--- a/src/adlmidi_opl3.cpp
+++ b/src/adlmidi_opl3.cpp
@@ -29,7 +29,10 @@
 #ifdef ADLMIDI_HW_OPL
 static const unsigned OPLBase = 0x388;
 #else
-#   if defined(ADLMIDI_DISABLE_NUKED_EMULATOR) && defined(ADLMIDI_DISABLE_DOSBOX_EMULATOR)
+#   if defined(ADLMIDI_DISABLE_NUKED_EMULATOR) && \
+       defined(ADLMIDI_DISABLE_DOSBOX_EMULATOR) && \
+       defined(ADLMIDI_DISABLE_OPAL_EMULATOR) && \
+       defined(ADLMIDI_DISABLE_JAVA_EMULATOR)
 #       error "No emulators enabled. You must enable at least one emulator to use this library!"
 #   endif
 


### PR DESCRIPTION
Add all emulators to the preprocessor directive that ensures at least one is enabled.

This was broken when I tried to build with only `OPAL` or `JAVA` emulator enabled.