### PR TITLE
WIP MIDIplay v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,8 @@ set(libADLMIDI_SOURCES
     ${libADLMIDI_SOURCE_DIR}/src/adlmidi_midiplay.cpp
     ${libADLMIDI_SOURCE_DIR}/src/adlmidi_opl3.cpp
     ${libADLMIDI_SOURCE_DIR}/src/adlmidi_private.cpp
+    ${libADLMIDI_SOURCE_DIR}/src/midiplay/chip_voice.cpp
+    ${libADLMIDI_SOURCE_DIR}/src/midiplay/cpp_extras.cpp
     ${libADLMIDI_SOURCE_DIR}/src/wopl/wopl_file.c
 )
 
@@ -225,6 +227,7 @@ if(libADLMIDI_STATIC OR WITH_VLC_PLUGIN)
     add_library(ADLMIDI_static STATIC ${libADLMIDI_SOURCES})
     set_target_properties(ADLMIDI_static PROPERTIES OUTPUT_NAME ADLMIDI)
     target_include_directories(ADLMIDI_static PUBLIC ${libADLMIDI_SOURCE_DIR}/include)
+    target_include_directories(ADLMIDI_static PRIVATE ${libADLMIDI_SOURCE_DIR}/src)
     set_legacy_standard(ADLMIDI_static)
     set_visibility_hidden(ADLMIDI_static)
     handle_options(ADLMIDI_static)
@@ -238,6 +241,7 @@ if(libADLMIDI_SHARED)
     add_library(ADLMIDI_shared SHARED ${libADLMIDI_SOURCES})
     set_target_properties(ADLMIDI_shared PROPERTIES OUTPUT_NAME ADLMIDI)
     target_include_directories(ADLMIDI_shared PUBLIC ${libADLMIDI_SOURCE_DIR}/include)
+    target_include_directories(ADLMIDI_shared PRIVATE ${libADLMIDI_SOURCE_DIR}/src)
     set_legacy_standard(ADLMIDI_shared)
     set_visibility_hidden(ADLMIDI_shared)
     handle_options(ADLMIDI_shared)

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -1254,7 +1254,7 @@ ADLMIDI_EXPORT int adl_playFormat(ADL_MIDIPlayer *device, int sampleCount,
 
     MidiPlayer *player = GET_MIDI_PLAYER(device);
     assert(player);
-    MidiPlayer::Setup &setup = player->m_setup;
+    MIDIsetup &setup = player->m_setup;
 
     ssize_t gotten_len = 0;
     ssize_t n_periodCountStereo = 512;
@@ -1362,7 +1362,7 @@ ADLMIDI_EXPORT int adl_generateFormat(struct ADL_MIDIPlayer *device, int sampleC
 
     MidiPlayer *player = GET_MIDI_PLAYER(device);
     assert(player);
-    MidiPlayer::Setup &setup = player->m_setup;
+    MIDIsetup &setup = player->m_setup;
 
     ssize_t gotten_len = 0;
     ssize_t n_periodCountStereo = 512;

--- a/src/midiplay/chip_voice.cpp
+++ b/src/midiplay/chip_voice.cpp
@@ -1,0 +1,43 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "chip_voice.hpp"
+#include <algorithm>
+
+void ChipChannel::addAge(int64_t us)
+{
+    const int64_t neg = 1000 * static_cast<int64_t>(-0x1FFFFFFFl);
+    if(users.empty())
+    {
+        koff_time_until_neglible_us = std::max(koff_time_until_neglible_us - us, neg);
+        if(koff_time_until_neglible_us < 0)
+            koff_time_until_neglible_us = 0;
+    }
+    else
+    {
+        koff_time_until_neglible_us = 0;
+        for(users_iterator i = users.begin(); !i.is_end(); ++i)
+        {
+            LocationData &d = i->value;
+            if(!d.fixed_sustain)
+                d.kon_time_until_neglible_us = std::max(d.kon_time_until_neglible_us - us, neg);
+            d.vibdelay_us += us;
+        }
+    }
+}

--- a/src/midiplay/chip_voice.hpp
+++ b/src/midiplay/chip_voice.hpp
@@ -1,0 +1,120 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPLMIDI_MIDIPLAY_PLAYER_HPP
+#define OPLMIDI_MIDIPLAY_PLAYER_HPP
+
+#pragma message("TODO: get rid of include")
+#include "midi_channel.hpp"
+#include "structures/pl_list.hpp"
+
+/**
+ * @brief Additional information about OPL3 channels
+ */
+struct ChipChannel
+{
+    struct Location
+    {
+        uint16_t    MidCh;
+        uint8_t     note;
+        bool operator==(const Location &l) const
+            { return MidCh == l.MidCh && note == l.note; }
+        bool operator!=(const Location &l) const
+            { return !operator==(l); }
+    };
+    struct LocationData
+    {
+        Location loc;
+        enum {
+            Sustain_None        = 0x00,
+            Sustain_Pedal       = 0x01,
+            Sustain_Sostenuto   = 0x02,
+            Sustain_ANY         = Sustain_Pedal | Sustain_Sostenuto
+        };
+        uint32_t sustained;
+        char _padding[6];
+        MIDIchannel::NoteInfo::Phys ins;  // a copy of that in phys[]
+        //! Has fixed sustain, don't iterate "on" timeout
+        bool    fixed_sustain;
+        //! Timeout until note will be allowed to be killed by channel manager while it is on
+        int64_t kon_time_until_neglible_us;
+        int64_t vibdelay_us;
+
+        struct FindPredicate
+        {
+            explicit FindPredicate(Location loc)
+                : loc(loc) {}
+            bool operator()(const LocationData &ld) const
+                { return ld.loc == loc; }
+            Location loc;
+        };
+    };
+
+    //! Time left until sounding will be muted after key off
+    int64_t koff_time_until_neglible_us;
+
+    //! Recently passed instrument, improves a goodness of released but busy channel when matching
+    MIDIchannel::NoteInfo::Phys recent_ins;
+
+    pl_list<LocationData> users;
+    typedef pl_list<LocationData>::iterator users_iterator;
+    typedef pl_list<LocationData>::const_iterator const_users_iterator;
+
+    users_iterator find_user(const Location &loc)
+    {
+        return users.find_if(LocationData::FindPredicate(loc));
+    }
+
+    users_iterator find_or_create_user(const Location &loc)
+    {
+        users_iterator it = find_user(loc);
+        if(it.is_end() && users.size() != users.capacity())
+        {
+            LocationData ld;
+            ld.loc = loc;
+            it = users.insert(users.end(), ld);
+        }
+        return it;
+    }
+
+    // For channel allocation:
+    ChipChannel(): koff_time_until_neglible_us(0), users(128)
+    {
+        std::memset(&recent_ins, 0, sizeof(MIDIchannel::NoteInfo::Phys));
+    }
+
+    ChipChannel(const ChipChannel &oth): koff_time_until_neglible_us(oth.koff_time_until_neglible_us), users(oth.users)
+    {
+    }
+
+    ChipChannel &operator=(const ChipChannel &oth)
+    {
+        koff_time_until_neglible_us = oth.koff_time_until_neglible_us;
+        users = oth.users;
+        return *this;
+    }
+
+    /**
+     * @brief Increases age of active note in microseconds time
+     * @param us Amount time in microseconds
+     */
+    void addAge(int64_t us);
+};
+
+#endif // OPLMIDI_MIDIPLAY_PLAYER_HPP

--- a/src/midiplay/cpp_extras.cpp
+++ b/src/midiplay/cpp_extras.cpp
@@ -1,0 +1,252 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "adlmidi_private.hpp"
+#include "adlmidi_midiplay.hpp"
+#include "adlmidi_opl3.hpp"
+
+#ifndef ADLMIDI_DISABLE_CPP_EXTRAS
+
+struct AdlInstrumentTester::Impl
+{
+    uint32_t cur_gm;
+    uint32_t ins_idx;
+    std::vector<uint32_t> adl_ins_list;
+    Synth *opl;
+    MIDIplay *play;
+};
+
+ADLMIDI_EXPORT AdlInstrumentTester::AdlInstrumentTester(ADL_MIDIPlayer *device)
+    : P(new Impl)
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    MIDIplay *play = reinterpret_cast<MIDIplay *>(device->adl_midiPlayer);
+    P->cur_gm = 0;
+    P->ins_idx = 0;
+    P->play = play;
+    P->opl = play ? play->m_synth.get() : NULL;
+#else
+    ADL_UNUSED(device);
+#endif
+}
+
+ADLMIDI_EXPORT AdlInstrumentTester::~AdlInstrumentTester()
+{
+    delete P;
+}
+
+ADLMIDI_EXPORT void AdlInstrumentTester::FindAdlList()
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    const unsigned NumBanks = (unsigned)adl_getBanksCount();
+    std::set<unsigned> adl_ins_set;
+    for(unsigned bankno = 0; bankno < NumBanks; ++bankno)
+        adl_ins_set.insert(banks[bankno][P->cur_gm]);
+    P->adl_ins_list.assign(adl_ins_set.begin(), adl_ins_set.end());
+    P->ins_idx = 0;
+    NextAdl(0);
+    P->opl->silenceAll();
+#endif
+}
+
+
+
+ADLMIDI_EXPORT void AdlInstrumentTester::Touch(unsigned c, unsigned volume) // Volume maxes at 127*127*127
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    Synth *opl = P->opl;
+    if(opl->m_volumeScale == Synth::VOLUME_NATIVE)
+        opl->touchNote(c, static_cast<uint8_t>(volume * 127 / (127 * 127 * 127) / 2));
+    else
+    {
+        // The formula below: SOLVE(V=127^3 * 2^( (A-63.49999) / 8), A)
+        opl->touchNote(c, static_cast<uint8_t>(volume > 8725 ? static_cast<unsigned int>(std::log((double)volume) * 11.541561 + (0.5 - 104.22845)) : 0));
+        // The incorrect formula below: SOLVE(V=127^3 * (2^(A/63)-1), A)
+        //Touch_Real(c, volume>11210 ? 91.61112 * std::log(4.8819E-7*volume + 1.0)+0.5 : 0);
+    }
+#else
+    ADL_UNUSED(c);
+    ADL_UNUSED(volume);
+#endif
+}
+
+ADLMIDI_EXPORT void AdlInstrumentTester::DoNote(int note)
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    MIDIplay *play = P->play;
+    Synth *opl = P->opl;
+    if(P->adl_ins_list.empty()) FindAdlList();
+    const unsigned meta = P->adl_ins_list[P->ins_idx];
+    const adlinsdata2 ains = adlinsdata2::from_adldata(::adlins[meta]);
+
+    int tone = (P->cur_gm & 128) ? (P->cur_gm & 127) : (note + 50);
+    if(ains.tone)
+    {
+        /*if(ains.tone < 20)
+                tone += ains.tone;
+            else */
+        if(ains.tone < 128)
+            tone = ains.tone;
+        else
+            tone -= ains.tone - 128;
+    }
+    double hertz = 172.00093 * std::exp(0.057762265 * (tone + 0.0));
+    int32_t adlchannel[2] = { 0, 3 };
+    if((ains.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) == 0)
+    {
+        adlchannel[1] = -1;
+        adlchannel[0] = 6; // single-op
+        if(play->hooks.onDebugMessage)
+        {
+            play->hooks.onDebugMessage(play->hooks.onDebugMessage_userData,
+                                       "noteon at %d for %g Hz\n", adlchannel[0], hertz);
+        }
+    }
+    else
+    {
+        if(play->hooks.onDebugMessage)
+        {
+            play->hooks.onDebugMessage(play->hooks.onDebugMessage_userData,
+                                       "noteon at %d and %d for %g Hz\n", adlchannel[0], adlchannel[1], hertz);
+        }
+    }
+
+    opl->noteOff(0);
+    opl->noteOff(3);
+    opl->noteOff(6);
+    for(unsigned c = 0; c < 2; ++c)
+    {
+        if(adlchannel[c] < 0) continue;
+        opl->setPatch(static_cast<size_t>(adlchannel[c]), ains.adl[c]);
+        opl->touchNote(static_cast<size_t>(adlchannel[c]), 63);
+        opl->setPan(static_cast<size_t>(adlchannel[c]), 0x30);
+        opl->noteOn(static_cast<size_t>(adlchannel[c]), static_cast<size_t>(adlchannel[1]), hertz);
+    }
+#else
+    ADL_UNUSED(note);
+#endif
+}
+
+ADLMIDI_EXPORT void AdlInstrumentTester::NextGM(int offset)
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    P->cur_gm = (P->cur_gm + 256 + (uint32_t)offset) & 0xFF;
+    FindAdlList();
+#else
+    ADL_UNUSED(offset);
+#endif
+}
+
+ADLMIDI_EXPORT void AdlInstrumentTester::NextAdl(int offset)
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    //Synth *opl = P->opl;
+    if(P->adl_ins_list.empty()) FindAdlList();
+    const unsigned NumBanks = (unsigned)adl_getBanksCount();
+    P->ins_idx = (uint32_t)((int32_t)P->ins_idx + (int32_t)P->adl_ins_list.size() + offset) % (int32_t)P->adl_ins_list.size();
+
+#if 0
+    UI.Color(15);
+    std::fflush(stderr);
+    std::printf("SELECTED G%c%d\t%s\n",
+                cur_gm < 128 ? 'M' : 'P', cur_gm < 128 ? cur_gm + 1 : cur_gm - 128,
+                "<-> select GM, ^v select ins, qwe play note");
+    std::fflush(stdout);
+    UI.Color(7);
+    std::fflush(stderr);
+#endif
+
+    for(size_t a = 0, n = P->adl_ins_list.size(); a < n; ++a)
+    {
+        const unsigned i = P->adl_ins_list[a];
+        const adlinsdata2 ains = adlinsdata2::from_adldata(::adlins[i]);
+
+        char ToneIndication[8] = "   ";
+        if(ains.tone)
+        {
+            /*if(ains.tone < 20)
+                    snprintf(ToneIndication, 8, "+%-2d", ains.tone);
+                else*/
+            if(ains.tone < 128)
+                snprintf(ToneIndication, 8, "=%-2d", ains.tone);
+            else
+                snprintf(ToneIndication, 8, "-%-2d", ains.tone - 128);
+        }
+        std::printf("%s%s%s%u\t",
+                    ToneIndication,
+                    (ains.flags & (adlinsdata::Flag_Pseudo4op|adlinsdata::Flag_Real4op)) ? "[2]" : "   ",
+                    (P->ins_idx == a) ? "->" : "\t",
+                    i
+                   );
+
+        for(unsigned bankno = 0; bankno < NumBanks; ++bankno)
+            if(banks[bankno][P->cur_gm] == i)
+                std::printf(" %u", bankno);
+
+        std::printf("\n");
+    }
+#else
+    ADL_UNUSED(offset);
+#endif
+}
+
+ADLMIDI_EXPORT bool AdlInstrumentTester::HandleInputChar(char ch)
+{
+#ifndef DISABLE_EMBEDDED_BANKS
+    static const char notes[] = "zsxdcvgbhnjmq2w3er5t6y7ui9o0p";
+    //                           c'd'ef'g'a'bC'D'EF'G'A'Bc'd'e
+    switch(ch)
+    {
+    case '/':
+    case 'H':
+    case 'A':
+        NextAdl(-1);
+        break;
+    case '*':
+    case 'P':
+    case 'B':
+        NextAdl(+1);
+        break;
+    case '-':
+    case 'K':
+    case 'D':
+        NextGM(-1);
+        break;
+    case '+':
+    case 'M':
+    case 'C':
+        NextGM(+1);
+        break;
+    case 3:
+#if !((!defined(__WIN32__) || defined(__CYGWIN__)) && !defined(__DJGPP__))
+    case 27:
+#endif
+        return false;
+    default:
+        const char *p = std::strchr(notes, ch);
+        if(p && *p)
+            DoNote((int)(p - notes) - 12);
+    }
+#else
+    ADL_UNUSED(ch);
+#endif
+    return true;
+}
+
+#endif /* ADLMIDI_DISABLE_CPP_EXTRAS */

--- a/src/midiplay/event_hooks.hpp
+++ b/src/midiplay/event_hooks.hpp
@@ -1,0 +1,48 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPLMIDI_MIDIPLAY_EVENT_HOOKS_HPP
+#define OPLMIDI_MIDIPLAY_EVENT_HOOKS_HPP
+
+#include <cstddef>
+
+/**
+ * @brief Hooks of the internal events
+ */
+struct MIDIEventHooks
+{
+    MIDIEventHooks() :
+        onNote(NULL),
+        onNote_userData(NULL),
+        onDebugMessage(NULL),
+        onDebugMessage_userData(NULL)
+    {}
+
+    //! Note on/off hooks
+    typedef void (*NoteHook)(void *userdata, int adlchn, int note, int ins, int pressure, double bend);
+    NoteHook     onNote;
+    void         *onNote_userData;
+
+    //! Library internal debug messages
+    typedef void (*DebugMessageHook)(void *userdata, const char *fmt, ...);
+    DebugMessageHook onDebugMessage;
+    void *onDebugMessage_userData;
+};
+
+#endif // OPLMIDI_MIDIPLAY_EVENT_HOOKS_HPP

--- a/src/midiplay/midi_channel.hpp
+++ b/src/midiplay/midi_channel.hpp
@@ -1,0 +1,342 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPLMIDI_MIDIPLAY_MIDI_CHANNEL_HPP
+#define OPLMIDI_MIDIPLAY_MIDI_CHANNEL_HPP
+
+#include "adldata.hh"
+#include "structures/pl_list.hpp"
+#include <cmath>
+#include <cstddef>
+#include <cassert>
+#include <stdint.h>
+
+/**
+ * @brief Persistent settings for each MIDI channel
+ */
+struct MIDIchannel
+{
+    //! LSB Bank number
+    uint8_t bank_lsb,
+    //! MSB Bank number
+            bank_msb;
+    //! Current patch number
+    uint8_t patch;
+    //! Volume level
+    uint8_t volume,
+    //! Expression level
+            expression;
+    //! Panning level
+    uint8_t panning,
+    //! Vibrato level
+            vibrato,
+    //! Channel aftertouch level
+            aftertouch;
+    //! Portamento time
+    uint16_t portamento;
+    //! Is Pedal sustain active
+    bool sustain;
+    //! Is Soft pedal active
+    bool softPedal;
+    //! Is portamento enabled
+    bool portamentoEnable;
+    //! Source note number used by portamento
+    int8_t portamentoSource;  // note number or -1
+    //! Portamento rate
+    double portamentoRate;
+    //! Per note Aftertouch values
+    uint8_t noteAftertouch[128];
+    //! Is note aftertouch has any non-zero value
+    bool    noteAfterTouchInUse;
+    //! Reserved
+    char _padding[6];
+    //! Pitch bend value
+    int bend;
+    //! Pitch bend sensitivity
+    double bendsense;
+    //! Pitch bend sensitivity LSB value
+    int bendsense_lsb,
+    //! Pitch bend sensitivity MSB value
+        bendsense_msb;
+    //! Vibrato position value
+    double  vibpos,
+    //! Vibrato speed value
+            vibspeed,
+    //! Vibrato depth value
+            vibdepth;
+    //! Vibrato delay time
+    int64_t vibdelay_us;
+    //! Last LSB part of RPN value received
+    uint8_t lastlrpn,
+    //! Last MSB poart of RPN value received
+            lastmrpn;
+    //! Interpret RPN value as NRPN
+    bool nrpn;
+    //! Brightness level
+    uint8_t brightness;
+
+    //! Is melodic channel turned into percussion
+    bool is_xg_percussion;
+
+    /**
+     * @brief Per-Note information
+     */
+    struct NoteInfo
+    {
+        //! Note number
+        uint8_t note;
+        //! Current pressure
+        uint8_t vol;
+        //! Note vibrato (a part of Note Aftertouch feature)
+        uint8_t vibrato;
+        //! Tone selected on noteon:
+        int16_t noteTone;
+        //! Current tone (!= noteTone if gliding note)
+        double currentTone;
+        //! Gliding rate
+        double glideRate;
+        //! Patch selected on noteon; index to bank.ins[]
+        size_t  midiins;
+        //! Is note the percussion instrument
+        bool    isPercussion;
+        //! Note that plays missing instrument. Doesn't using any chip channels
+        bool    isBlank;
+        //! Whether releasing and on extended life time defined by TTL
+        bool    isOnExtendedLifeTime;
+        //! Time-to-live until release (short percussion note fix)
+        double  ttl;
+        //! Patch selected
+        const adlinsdata2 *ains;
+        enum
+        {
+            MaxNumPhysChans = 2,
+            MaxNumPhysItemCount = MaxNumPhysChans
+        };
+
+        struct FindPredicate
+        {
+            explicit FindPredicate(unsigned note)
+                : note(note) {}
+            bool operator()(const NoteInfo &ni) const
+                { return ni.note == note; }
+            unsigned note;
+        };
+
+        /**
+         * @brief Reference to currently using chip channel
+         */
+        struct Phys
+        {
+            //! Destination chip channel
+            uint16_t chip_chan;
+            //! ins, inde to adl[]
+            adldata ains;
+            //! Is this voice must be detunable?
+            bool    pseudo4op;
+
+            void assign(const Phys &oth)
+            {
+                ains = oth.ains;
+                pseudo4op = oth.pseudo4op;
+            }
+            bool operator==(const Phys &oth) const
+            {
+                return (ains == oth.ains) && (pseudo4op == oth.pseudo4op);
+            }
+            bool operator!=(const Phys &oth) const
+            {
+                return !operator==(oth);
+            }
+        };
+
+        //! List of OPL3 channels it is currently occupying.
+        Phys chip_channels[MaxNumPhysItemCount];
+        //! Count of used channels.
+        unsigned chip_channels_count;
+
+        Phys *phys_find(unsigned chip_chan)
+        {
+            Phys *ph = NULL;
+            for(unsigned i = 0; i < chip_channels_count && !ph; ++i)
+                if(chip_channels[i].chip_chan == chip_chan)
+                    ph = &chip_channels[i];
+            return ph;
+        }
+        Phys *phys_find_or_create(uint16_t chip_chan)
+        {
+            Phys *ph = phys_find(chip_chan);
+            if(!ph) {
+                if(chip_channels_count < MaxNumPhysItemCount) {
+                    ph = &chip_channels[chip_channels_count++];
+                    ph->chip_chan = chip_chan;
+                }
+            }
+            return ph;
+        }
+        Phys *phys_ensure_find_or_create(uint16_t chip_chan)
+        {
+            Phys *ph = phys_find_or_create(chip_chan);
+            assert(ph);
+            return ph;
+        }
+        void phys_erase_at(const Phys *ph)
+        {
+            intptr_t pos = ph - chip_channels;
+            assert(pos < static_cast<intptr_t>(chip_channels_count));
+            for(intptr_t i = pos + 1; i < static_cast<intptr_t>(chip_channels_count); ++i)
+                chip_channels[i - 1] = chip_channels[i];
+            --chip_channels_count;
+        }
+        void phys_erase(unsigned chip_chan)
+        {
+            Phys *ph = phys_find(chip_chan);
+            if(ph)
+                phys_erase_at(ph);
+        }
+    };
+
+    //! Reserved
+    char _padding2[5];
+    //! Count of gliding notes in this channel
+    unsigned gliding_note_count;
+    //! Count of notes having a TTL countdown in this channel
+    unsigned extended_note_count;
+
+    //! Active notes in the channel
+    pl_list<NoteInfo> activenotes;
+    typedef pl_list<NoteInfo>::iterator notes_iterator;
+    typedef pl_list<NoteInfo>::const_iterator const_notes_iterator;
+
+    notes_iterator find_activenote(unsigned note)
+    {
+        return activenotes.find_if(NoteInfo::FindPredicate(note));
+    }
+
+    notes_iterator ensure_find_activenote(unsigned note)
+    {
+        notes_iterator it = find_activenote(note);
+        assert(!it.is_end());
+        return it;
+    }
+
+    notes_iterator find_or_create_activenote(unsigned note)
+    {
+        notes_iterator it = find_activenote(note);
+        if(!it.is_end())
+            cleanupNote(it);
+        else
+        {
+            NoteInfo ni;
+            ni.note = note;
+            it = activenotes.insert(activenotes.end(), ni);
+        }
+        return it;
+    }
+
+    notes_iterator ensure_find_or_create_activenote(unsigned note)
+    {
+        notes_iterator it = find_or_create_activenote(note);
+        assert(!it.is_end());
+        return it;
+    }
+
+    /**
+     * @brief Reset channel into initial state
+     */
+    void reset()
+    {
+        resetAllControllers();
+        patch = 0;
+        vibpos = 0;
+        bank_lsb = 0;
+        bank_msb = 0;
+        lastlrpn = 0;
+        lastmrpn = 0;
+        nrpn = false;
+        is_xg_percussion = false;
+    }
+
+    /**
+     * @brief Reset all MIDI controllers into initial state
+     */
+    void resetAllControllers()
+    {
+        bend = 0;
+        bendsense_msb = 2;
+        bendsense_lsb = 0;
+        updateBendSensitivity();
+        volume  = 100;
+        expression = 127;
+        sustain = false;
+        softPedal = false;
+        vibrato = 0;
+        aftertouch = 0;
+        std::memset(noteAftertouch, 0, 128);
+        noteAfterTouchInUse = false;
+        vibspeed = 2 * 3.141592653 * 5.0;
+        vibdepth = 0.5 / 127;
+        vibdelay_us = 0;
+        panning = 64;
+        portamento = 0;
+        portamentoEnable = false;
+        portamentoSource = -1;
+        portamentoRate = HUGE_VAL;
+        brightness = 127;
+    }
+
+    /**
+     * @brief Has channel vibrato to process
+     * @return
+     */
+    bool hasVibrato()
+    {
+        return (vibrato > 0) || (aftertouch > 0) || noteAfterTouchInUse;
+    }
+
+    /**
+     * @brief Commit pitch bend sensitivity value from MSB and LSB
+     */
+    void updateBendSensitivity()
+    {
+        int cent = bendsense_msb * 128 + bendsense_lsb;
+        bendsense = cent * (1.0 / (128 * 8192));
+    }
+
+    /**
+     * @brief Clean up the state of the active note before removal
+     */
+    void cleanupNote(notes_iterator i)
+    {
+        NoteInfo &info = i->value;
+        if(info.glideRate != HUGE_VAL)
+            --gliding_note_count;
+        if(info.ttl > 0)
+            --extended_note_count;
+    }
+
+    MIDIchannel()
+        : activenotes(128)
+    {
+        gliding_note_count = 0;
+        extended_note_count = 0;
+        reset();
+    }
+};
+
+#endif // OPLMIDI_MIDIPLAY_MIDI_CHANNEL_HPP

--- a/src/midiplay/player.hpp
+++ b/src/midiplay/player.hpp
@@ -1,0 +1,23 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPLMIDI_MIDIPLAY_PLAYER_HPP
+#define OPLMIDI_MIDIPLAY_PLAYER_HPP
+
+#endif // OPLMIDI_MIDIPLAY_PLAYER_HPP

--- a/src/midiplay/setup.hpp
+++ b/src/midiplay/setup.hpp
@@ -1,0 +1,56 @@
+/*
+ * libADLMIDI is a free Software MIDI synthesizer library with OPL3 emulation
+ *
+ * ADLMIDI Library API:   Copyright (c) 2015-2019 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPLMIDI_MIDIPLAY_SETUP_HPP
+#define OPLMIDI_MIDIPLAY_SETUP_HPP
+
+#include <cstdio>
+
+struct MIDIsetup
+{
+    int          emulator;
+    bool         runAtPcmRate;
+    unsigned int bankId;
+    int          numFourOps;
+    unsigned int numChips;
+    int     deepTremoloMode;
+    int     deepVibratoMode;
+    int     rhythmMode;
+    bool    logarithmicVolumes;
+    int     volumeScaleModel;
+    //unsigned int SkipForward;
+    int     scaleModulators;
+    bool    fullRangeBrightnessCC74;
+
+    double delay;
+    double carry;
+
+    /* The lag between visual content and audio content equals */
+    /* the sum of these two buffers. */
+    double mindelay;
+    double maxdelay;
+
+    /* For internal usage */
+    ssize_t tick_skip_samples_delay; /* Skip tick processing after samples count. */
+    /* For internal usage */
+
+    unsigned long PCM_RATE;
+};
+
+#endif // OPLMIDI_MIDIPLAY_SETUP_HPP


### PR DESCRIPTION
**:warning: Not ready for merge**

Beginning of "v2" work for the MIDI player

For now, code is kept mostly as usual, there will be more rearranging.
One of the things is to split the huge structure.

It is separated in distinct source files for each logical part, if you agree with it.
Files are tagged with an `OPLMIDI` identifier.

The term of "chip voices" is adopted in file naming, does not exist yet in source.
It's the intent to be more generic, and the idea to be associated to chip channels in `1..*` way.
It's the place for a kind of polymorphic structure which can host a voice of any kind.
As such, it's intended to have the definition for "FM voice", "rhythm voice", "PSG", "PCM"  etc.

The voices will be able to be type-switched for dynamic 2-op/4-op conversion.
A tagged union will be appropriate for implementing.

Other things:
- copy constructors, as when resizing channels when adding devices/chips: eliminate
- nested structures remaining: move to upper level, rename as needed
- add generic pool of memory; it will ease implementing a buffering of note-offs, and fix in that way the "Dance of sugar-plum fairy" that Joel has noted, but **without** counting on single-time note keying.
- I want also to setup the channel<->voice Location by a better linked model which accessible by both directions