### PR TITLE
Avoid home-grown integer types

### DIFF
--- a/src/wopl/wopl_file.h
+++ b/src/wopl/wopl_file.h
@@ -32,14 +32,6 @@
 extern "C" {
 #endif
 
-#if !defined(__STDC_VERSION__) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ < 199901L)) \
-  || defined(__STRICT_ANSI__) || !defined(__cplusplus)
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int int16_t;
-typedef unsigned short int uint16_t;
-#endif
-
 /* Global OPL flags */
 typedef enum WOPLFileFlags
 {


### PR DESCRIPTION
This is intended to fix compile errors on some operating systems.