### PR TITLE
CMake: respect BUILD_SHARED_LIBS setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,18 @@ if(NOT EMSCRIPTEN
    AND NOT NINTENDO_WII
    AND NOT NINTENDO_WIIU
    AND NOT ADLMIDI_DOS)
-    option(libADLMIDI_STATIC   "Build static library of libADLMIDI" ON)
-    option(libADLMIDI_SHARED   "Build shared library of libADLMIDI" OFF)
+
+    set(libADLMIDI_STATIC_ENABLED_BY_DEFAULT ON)
+    set(libADLMIDI_SHARED_ENABLED_BY_DEFAULT OFF)
+
+    # When defined, respect CMake's BUILD_SHARED_LIBS setting
+    if (BUILD_SHARED_LIBS)
+        set(libADLMIDI_SHARED_ENABLED_BY_DEFAULT ON)
+        set(libADLMIDI_STATIC_ENABLED_BY_DEFAULT OFF)
+    endif()
+
+    option(libADLMIDI_STATIC   "Build static library of libADLMIDI" ${libADLMIDI_STATIC_ENABLED_BY_DEFAULT})
+    option(libADLMIDI_SHARED   "Build shared library of libADLMIDI" ${libADLMIDI_SHARED_ENABLED_BY_DEFAULT})
 else()
     set(libADLMIDI_STATIC ON)
     set(libADLMIDI_SHARED OFF)


### PR DESCRIPTION
It's a good practice to respect BUILD_SHARED_LIBS setting. 
It will be easier to integrate the library to projects and build systems.