### PR TITLE
Import latest Nuked OPL 1.8 code

### DIFF
--- a/src/chips/nuked/LICENSE
+++ b/src/chips/nuked/LICENSE
@@ -1,0 +1,504 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random
+  Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/src/chips/nuked/nukedopl3.c
+++ b/src/chips/nuked/nukedopl3.c
@@ -1402,7 +1402,7 @@ inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
         mix[0] += (int16_t)((accm * channel->rightpan) >> 16);
 #else
         mix[0] += (int16_t)((accm * chip->channel[ii].chr / 65535) & channel->chb);
- #endif
+#endif
         mix[1] += (int16_t)(accm & channel->chd);
     }
     chip->mixbuff[1] = mix[0];

--- a/src/chips/nuked/nukedopl3.c
+++ b/src/chips/nuked/nukedopl3.c
@@ -1,20 +1,21 @@
-/*
- * Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
+/* Nuked OPL3
+ * Copyright (C) 2013-2020 Nuke.YKT
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * This file is part of Nuked OPL3.
  *
- * This library is distributed in the hope that it will be useful,
+ * Nuked OPL3 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * Nuked OPL3 is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuked OPL3. If not, see <https://www.gnu.org/licenses/>.
+
  *  Nuked OPL3 emulator.
  *  Thanks:
  *      MAME Development Team(Jarek Burczynski, Tatsuyuki Satoh):
@@ -33,6 +34,20 @@
 #include <stdlib.h>
 #include <string.h>
 #include "nukedopl3.h"
+
+#if OPL_ENABLE_STEREOEXT && !defined OPL_SIN
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES 1
+#endif
+#include <math.h>
+/* input: [0, 256), output: [0, 65536] */
+#define OPL_SIN(x) ((int32_t)(sin((x) * M_PI / 512.0) * 65536.0))
+#endif
+
+/* Quirk: Some FM channels are output one sample later on the left side than the right. */
+#ifndef OPL_QUIRK_CHANNELSAMPLEDELAY
+#define OPL_QUIRK_CHANNELSAMPLEDELAY (!OPL_ENABLE_STEREOEXT)
+#endif
 
 #define RSM_FRAC    10
 
@@ -55,10 +70,10 @@ enum {
 
 #if OPL_FAST_WAVEGEN
 /*
- * logsin table
- */
+    logsin table
+*/
 
-static const Bit16u logsinrom[512] = {
+static const uint16_t logsinrom[512] = {
     0x859, 0x6c3, 0x607, 0x58b, 0x52e, 0x4e4, 0x4a6, 0x471,
     0x443, 0x41a, 0x3f5, 0x3d3, 0x3b5, 0x398, 0x37e, 0x365,
     0x34e, 0x339, 0x324, 0x311, 0x2ff, 0x2ed, 0x2dc, 0x2cd,
@@ -126,10 +141,10 @@ static const Bit16u logsinrom[512] = {
 };
 
 /*
- * exp table
- */
+    exp table
+*/
 
-static const Bit16u exprom[256] = {
+static const uint16_t exprom[256] = {
     0xff4, 0xfea, 0xfde, 0xfd4, 0xfc8, 0xfbe, 0xfb4, 0xfa8,
     0xf9e, 0xf92, 0xf88, 0xf7e, 0xf72, 0xf68, 0xf5c, 0xf52,
     0xf48, 0xf3e, 0xf32, 0xf28, 0xf1e, 0xf14, 0xf08, 0xefe,
@@ -165,10 +180,10 @@ static const Bit16u exprom[256] = {
 };
 #else
 /*
- * logsin table
- */
+    logsin table
+*/
 
-static const Bit16u logsinrom[256] = {
+static const uint16_t logsinrom[256] = {
     0x859, 0x6c3, 0x607, 0x58b, 0x52e, 0x4e4, 0x4a6, 0x471,
     0x443, 0x41a, 0x3f5, 0x3d3, 0x3b5, 0x398, 0x37e, 0x365,
     0x34e, 0x339, 0x324, 0x311, 0x2ff, 0x2ed, 0x2dc, 0x2cd,
@@ -204,10 +219,10 @@ static const Bit16u logsinrom[256] = {
 };
 
 /*
- * exp table
- */
+    exp table
+*/
 
-static const Bit16u exprom[256] = {
+static const uint16_t exprom[256] = {
     0x7fa, 0x7f5, 0x7ef, 0x7ea, 0x7e4, 0x7df, 0x7da, 0x7d4,
     0x7cf, 0x7c9, 0x7c4, 0x7bf, 0x7b9, 0x7b4, 0x7ae, 0x7a9,
     0x7a4, 0x79f, 0x799, 0x794, 0x78f, 0x78a, 0x784, 0x77f,
@@ -244,32 +259,32 @@ static const Bit16u exprom[256] = {
 #endif
 
 /*
- * freq mult table multiplied by 2
- *
- * 1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 12, 12, 15, 15
- */
+    freq mult table multiplied by 2
 
-static const Bit8u mt[16] = {
+    1/2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 12, 12, 15, 15
+*/
+
+static const uint8_t mt[16] = {
     1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 20, 24, 24, 30, 30
 };
 
 /*
- * ksl table
- */
+    ksl table
+*/
 
-static const Bit8u kslrom[16] = {
+static const uint8_t kslrom[16] = {
     0, 32, 40, 45, 48, 51, 53, 55, 56, 58, 59, 60, 61, 62, 63, 64
 };
 
-static const Bit8u kslshift[4] = {
+static const uint8_t kslshift[4] = {
     8, 1, 2, 0
 };
 
 /*
- * envelope generator constants
- */
+    envelope generator constants
+*/
 
-static const Bit8u eg_incstep[4][4] = {
+static const uint8_t eg_incstep[4][4] = {
     { 0, 0, 0, 0 },
     { 1, 0, 0, 0 },
     { 1, 0, 1, 0 },
@@ -277,23 +292,32 @@ static const Bit8u eg_incstep[4][4] = {
 };
 
 /*
- * address decoding
- */
+    address decoding
+*/
 
-static const Bit8s ad_slot[0x20] = {
+static const int8_t ad_slot[0x20] = {
     0, 1, 2, 3, 4, 5, -1, -1, 6, 7, 8, 9, 10, 11, -1, -1,
     12, 13, 14, 15, 16, 17, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
 };
 
-static const Bit8u ch_slot[18] = {
+static const uint8_t ch_slot[18] = {
     0, 1, 2, 6, 7, 8, 12, 13, 14, 18, 19, 20, 24, 25, 26, 30, 31, 32
 };
 
+#if OPL_ENABLE_STEREOEXT
 /*
- * Pan law table
- */
+    stereo extension panning table
+*/
 
-static const Bit16u panlawtable[] =
+static int32_t panpot_lut[256];
+static uint8_t panpot_lut_build = 0;
+#endif
+
+/*
+    Pan law table
+*/
+
+static const uint16_t panlawtable[] =
 {
     65535, 65529, 65514, 65489, 65454, 65409, 65354, 65289,
     65214, 65129, 65034, 64929, 64814, 64689, 64554, 64410,
@@ -316,13 +340,14 @@ static const Bit16u panlawtable[] =
 };
 
 /*
- * Envelope generator
- */
+    Envelope generator
+*/
 
 #if !OPL_FAST_WAVEGEN
-typedef Bit16s(*envelope_sinfunc)(Bit16u phase, Bit16u envelope);
+typedef int16_t(*envelope_sinfunc)(uint16_t phase, uint16_t envelope);
+typedef void(*envelope_genfunc)(opl3_slot *slott);
 
-static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
+static int16_t OPL3_EnvelopeCalcExp(uint32_t level)
 {
     if (level > 0x1fff)
     {
@@ -331,10 +356,10 @@ static Bit16s OPL3_EnvelopeCalcExp(Bit32u level)
     return (exprom[level & 0xff] << 1) >> (level >> 8);
 }
 
-static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin0(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
-    Bit16u neg = 0;
+    uint16_t out = 0;
+    uint16_t neg = 0;
     phase &= 0x3ff;
     if (phase & 0x200)
     {
@@ -351,9 +376,9 @@ static Bit16s OPL3_EnvelopeCalcSin0(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3)) ^ neg;
 }
 
-static Bit16s OPL3_EnvelopeCalcSin1(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin1(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
+    uint16_t out = 0;
     phase &= 0x3ff;
     if (phase & 0x200)
     {
@@ -370,9 +395,9 @@ static Bit16s OPL3_EnvelopeCalcSin1(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-static Bit16s OPL3_EnvelopeCalcSin2(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin2(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
+    uint16_t out = 0;
     phase &= 0x3ff;
     if (phase & 0x100)
     {
@@ -385,9 +410,9 @@ static Bit16s OPL3_EnvelopeCalcSin2(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-static Bit16s OPL3_EnvelopeCalcSin3(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin3(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
+    uint16_t out = 0;
     phase &= 0x3ff;
     if (phase & 0x100)
     {
@@ -400,10 +425,10 @@ static Bit16s OPL3_EnvelopeCalcSin3(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin4(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
-    Bit16u neg = 0;
+    uint16_t out = 0;
+    uint16_t neg = 0;
     phase &= 0x3ff;
     if ((phase & 0x300) == 0x100)
     {
@@ -424,9 +449,9 @@ static Bit16s OPL3_EnvelopeCalcSin4(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3)) ^ neg;
 }
 
-static Bit16s OPL3_EnvelopeCalcSin5(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin5(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
+    uint16_t out = 0;
     phase &= 0x3ff;
     if (phase & 0x200)
     {
@@ -443,9 +468,9 @@ static Bit16s OPL3_EnvelopeCalcSin5(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(out + (envelope << 3));
 }
 
-static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin6(uint16_t phase, uint16_t envelope)
 {
-    Bit16u neg = 0;
+    uint16_t neg = 0;
     phase &= 0x3ff;
     if (phase & 0x200)
     {
@@ -454,10 +479,10 @@ static Bit16s OPL3_EnvelopeCalcSin6(Bit16u phase, Bit16u envelope)
     return OPL3_EnvelopeCalcExp(envelope << 3) ^ neg;
 }
 
-static Bit16s OPL3_EnvelopeCalcSin7(Bit16u phase, Bit16u envelope)
+static int16_t OPL3_EnvelopeCalcSin7(uint16_t phase, uint16_t envelope)
 {
-    Bit16u out = 0;
-    Bit16u neg = 0;
+    uint16_t out = 0;
+    uint16_t neg = 0;
     phase &= 0x3ff;
     if (phase & 0x200)
     {
@@ -490,28 +515,28 @@ enum envelope_gen_num
 
 static void OPL3_EnvelopeUpdateKSL(opl3_slot *slot)
 {
-    Bit16s ksl = (kslrom[slot->channel->f_num >> 6] << 2)
+    int16_t ksl = (kslrom[slot->channel->f_num >> 6] << 2)
                - ((0x08 - slot->channel->block) << 5);
     if (ksl < 0)
     {
         ksl = 0;
     }
-    slot->eg_ksl = (Bit8u)ksl;
+    slot->eg_ksl = (uint8_t)ksl;
 }
 
 static void OPL3_EnvelopeCalc(opl3_slot *slot)
 {
-    Bit8u nonzero;
-    Bit8u rate;
-    Bit8u rate_hi;
-    Bit8u rate_lo;
-    Bit8u reg_rate = 0;
-    Bit8u ks;
-    Bit8u eg_shift, shift;
-    Bit16u eg_rout;
-    Bit16s eg_inc;
-    Bit8u eg_off;
-    Bit8u reset = 0;
+    uint8_t nonzero;
+    uint8_t rate;
+    uint8_t rate_hi;
+    uint8_t rate_lo;
+    uint8_t reg_rate = 0;
+    uint8_t ks;
+    uint8_t eg_shift, shift;
+    uint16_t eg_rout;
+    int16_t eg_inc;
+    uint8_t eg_off;
+    uint8_t reset = 0;
     slot->eg_out = slot->eg_rout + (slot->reg_tl << 2)
                  + (slot->eg_ksl >> kslshift[slot->reg_ksl]) + *slot->trem;
 
@@ -622,7 +647,7 @@ static void OPL3_EnvelopeCalc(opl3_slot *slot)
         }
         else if (slot->key && shift > 0 && rate_hi != 0x0f)
         {
-            eg_inc = ((~slot->eg_rout) << shift) >> 4;
+            eg_inc = ~slot->eg_rout >> (4 - shift);
         }
         break;
     case envelope_gen_num_decay:
@@ -655,35 +680,35 @@ static void OPL3_EnvelopeCalc(opl3_slot *slot)
     }
 }
 
-static void OPL3_EnvelopeKeyOn(opl3_slot *slot, Bit8u type)
+static void OPL3_EnvelopeKeyOn(opl3_slot *slot, uint8_t type)
 {
     slot->key |= type;
 }
 
-static void OPL3_EnvelopeKeyOff(opl3_slot *slot, Bit8u type)
+static void OPL3_EnvelopeKeyOff(opl3_slot *slot, uint8_t type)
 {
     slot->key &= ~type;
 }
 
 /*
- * Phase Generator
- */
+    Phase Generator
+*/
 
 static void OPL3_PhaseGenerate(opl3_slot *slot)
 {
     opl3_chip *chip;
-    Bit16u f_num;
-    Bit32u basefreq;
-    Bit8u rm_xor, n_bit;
-    Bit32u noise;
-    Bit16u phase;
+    uint16_t f_num;
+    uint32_t basefreq;
+    uint8_t rm_xor, n_bit;
+    uint32_t noise;
+    uint16_t phase;
 
     chip = slot->chip;
     f_num = slot->channel->f_num;
     if (slot->reg_vib)
     {
-        Bit8s range;
-        Bit8u vibpos;
+        int8_t range;
+        uint8_t vibpos;
 
         range = (f_num >> 7) & 7;
         vibpos = slot->chip->vibpos;
@@ -705,7 +730,7 @@ static void OPL3_PhaseGenerate(opl3_slot *slot)
         f_num += range;
     }
     basefreq = (f_num << slot->channel->block) >> 1;
-    phase = (Bit16u)(slot->pg_phase >> 9);
+    phase = (uint16_t)(slot->pg_phase >> 9);
     if (slot->pg_reset)
     {
         slot->pg_phase = 0;
@@ -760,10 +785,10 @@ static void OPL3_PhaseGenerate(opl3_slot *slot)
 }
 
 /*
- * Slot
- */
+    Slot
+*/
 
-static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
+static void OPL3_SlotWrite20(opl3_slot *slot, uint8_t data)
 {
     if ((data >> 7) & 0x01)
     {
@@ -771,7 +796,7 @@ static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
     }
     else
     {
-        slot->trem = (Bit8u*)&slot->chip->zeromod;
+        slot->trem = (uint8_t*)&slot->chip->zeromod;
     }
     slot->reg_vib = (data >> 6) & 0x01;
     slot->reg_type = (data >> 5) & 0x01;
@@ -779,20 +804,20 @@ static void OPL3_SlotWrite20(opl3_slot *slot, Bit8u data)
     slot->reg_mult = data & 0x0f;
 }
 
-static void OPL3_SlotWrite40(opl3_slot *slot, Bit8u data)
+static void OPL3_SlotWrite40(opl3_slot *slot, uint8_t data)
 {
     slot->reg_ksl = (data >> 6) & 0x03;
     slot->reg_tl = data & 0x3f;
     OPL3_EnvelopeUpdateKSL(slot);
 }
 
-static void OPL3_SlotWrite60(opl3_slot *slot, Bit8u data)
+static void OPL3_SlotWrite60(opl3_slot *slot, uint8_t data)
 {
     slot->reg_ar = (data >> 4) & 0x0f;
     slot->reg_dr = data & 0x0f;
 }
 
-static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
+static void OPL3_SlotWrite80(opl3_slot *slot, uint8_t data)
 {
     slot->reg_sl = (data >> 4) & 0x0f;
     if (slot->reg_sl == 0x0f)
@@ -802,7 +827,7 @@ static void OPL3_SlotWrite80(opl3_slot *slot, Bit8u data)
     slot->reg_rr = data & 0x0f;
 }
 
-static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
+static void OPL3_SlotWriteE0(opl3_slot *slot, uint8_t data)
 {
     slot->reg_wf = data & 0x07;
     if (slot->chip->newm == 0x00)
@@ -863,9 +888,9 @@ static void OPL3_SlotWriteE0(opl3_slot *slot, Bit8u data)
 #if OPL_FAST_WAVEGEN
 static void OPL3_SlotGenerate(opl3_slot *slot)
 {
-    Bit16u phase = slot->pg_phase_out + *slot->mod;
-    Bit32u neg, level;
-    Bit8u  phaseshift;
+    uint16_t phase = slot->pg_phase_out + *slot->mod;
+    uint32_t neg, level;
+    uint8_t  phaseshift;
 
     /* Fast paths for mute segments */
     if (phase & slot->maskzero)
@@ -874,7 +899,7 @@ static void OPL3_SlotGenerate(opl3_slot *slot)
         return;
     }
 
-    neg = (Bit32s)((Bit32u)phase << slot->signpos) >> 31;
+    neg = (int32_t)((uint32_t)phase << slot->signpos) >> 31;
     phaseshift = slot->phaseshift;
     level = slot->eg_out;
 
@@ -910,17 +935,17 @@ static void OPL3_SlotCalcFB(opl3_slot *slot)
 }
 
 /*
- * Channel
- */
+    Channel
+*/
 
 static void OPL3_ChannelSetupAlg(opl3_channel *channel);
 
-static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
+static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, uint8_t data)
 {
     opl3_channel *channel6;
     opl3_channel *channel7;
     opl3_channel *channel8;
-    Bit8u chnum;
+    uint8_t chnum;
 
     chip->rhy = data & 0x3f;
     if (chip->rhy & 0x20)
@@ -1007,7 +1032,7 @@ static void OPL3_ChannelUpdateRhythm(opl3_chip *chip, Bit8u data)
     }
 }
 
-static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
+static void OPL3_ChannelWriteA0(opl3_channel *channel, uint8_t data)
 {
     if (channel->chip->newm && channel->chtype == ch_4op2)
     {
@@ -1027,7 +1052,7 @@ static void OPL3_ChannelWriteA0(opl3_channel *channel, Bit8u data)
     }
 }
 
-static void OPL3_ChannelWriteB0(opl3_channel *channel, Bit8u data)
+static void OPL3_ChannelWriteB0(opl3_channel *channel, uint8_t data)
 {
     if (channel->chip->newm && channel->chtype == ch_4op2)
     {
@@ -1150,10 +1175,8 @@ static void OPL3_ChannelSetupAlg(opl3_channel *channel)
     }
 }
 
-static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
+static void OPL3_ChannelUpdateAlg(opl3_channel *channel)
 {
-    channel->fb = (data & 0x0e) >> 1;
-    channel->con = data & 0x01;
     channel->alg = channel->con;
     if (channel->chip->newm)
     {
@@ -1178,16 +1201,45 @@ static void OPL3_ChannelWriteC0(opl3_channel *channel, Bit8u data)
     {
         OPL3_ChannelSetupAlg(channel);
     }
+}
+
+static void OPL3_ChannelWriteC0(opl3_channel *channel, uint8_t data)
+{
+    channel->fb = (data & 0x0e) >> 1;
+    channel->con = data & 0x01;
+    OPL3_ChannelUpdateAlg(channel);
     if (channel->chip->newm)
     {
         channel->cha = ((data >> 4) & 0x01) ? ~0 : 0;
         channel->chb = ((data >> 5) & 0x01) ? ~0 : 0;
+        channel->chc = ((data >> 6) & 0x01) ? ~0 : 0;
+        channel->chd = ((data >> 7) & 0x01) ? ~0 : 0;
     }
     else
     {
-        channel->cha = channel->chb = (Bit16u)~0;
+        channel->cha = channel->chb = (uint16_t)~0;
+        /* TODO: Verify on real chip if DAC2 output is disabled in compat mode */
+        channel->chc = channel->chd = 0;
+    }
+#if OPL_ENABLE_STEREOEXT
+    if (!channel->chip->stereoext)
+    {
+        channel->leftpan = channel->cha << 16;
+        channel->rightpan = channel->chb << 16;
+    }
+#endif
+}
+
+#if OPL_ENABLE_STEREOEXT
+static void OPL3_ChannelWriteD0(opl3_channel* channel, uint8_t data)
+{
+    if (channel->chip->stereoext)
+    {
+        channel->leftpan = panpot_lut[data ^ 0xff];
+        channel->rightpan = panpot_lut[data];
     }
 }
+#endif
 
 static void OPL3_ChannelKeyOn(opl3_channel *channel)
 {
@@ -1237,10 +1289,10 @@ static void OPL3_ChannelKeyOff(opl3_channel *channel)
     }
 }
 
-static void OPL3_ChannelSet4Op(opl3_chip *chip, Bit8u data)
+static void OPL3_ChannelSet4Op(opl3_chip *chip, uint8_t data)
 {
-    Bit8u bit;
-    Bit8u chnum;
+    uint8_t bit;
+    uint8_t chnum;
     for (bit = 0; bit < 6; bit++)
     {
         chnum = bit;
@@ -1252,16 +1304,19 @@ static void OPL3_ChannelSet4Op(opl3_chip *chip, Bit8u data)
         {
             chip->channel[chnum].chtype = ch_4op;
             chip->channel[chnum + 3].chtype = ch_4op2;
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum]);
         }
         else
         {
             chip->channel[chnum].chtype = ch_2op;
             chip->channel[chnum + 3].chtype = ch_2op;
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum]);
+            OPL3_ChannelUpdateAlg(&chip->channel[chnum+3]);
         }
     }
 }
 
-static Bit16s OPL3_ClipSample(Bit32s sample)
+static int16_t OPL3_ClipSample(int32_t sample)
 {
     if (sample > 32767)
     {
@@ -1271,73 +1326,94 @@ static Bit16s OPL3_ClipSample(Bit32s sample)
     {
         sample = -32768;
     }
-    return (Bit16s)sample;
+    return (int16_t)sample;
 }
 
-void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
+static void OPL3_ProcessSlot(opl3_slot *slot)
 {
-    Bit8u ii;
-    Bit8u jj;
-    Bit16s accm;
-    Bit8u shift = 0;
+    OPL3_SlotCalcFB(slot);
+    OPL3_EnvelopeCalc(slot);
+    OPL3_PhaseGenerate(slot);
+    OPL3_SlotGenerate(slot);
+}
 
-    buf[1] = OPL3_ClipSample(chip->mixbuff[1]);
+inline void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4)
+{
+    opl3_channel *channel;
+    opl3_writebuf *writebuf;
+    int16_t **out;
+    int32_t mix[2];
+    uint8_t ii;
+    int16_t accm;
+    uint8_t shift = 0;
 
+    buf4[1] = OPL3_ClipSample(chip->mixbuff[1]);
+    buf4[3] = OPL3_ClipSample(chip->mixbuff[3]);
+
+#if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 0; ii < 15; ii++)
+#else
+    for (ii = 0; ii < 36; ii++)
+#endif
     {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_SlotGenerate(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
 
-    chip->mixbuff[0] = 0;
+    mix[0] = mix[1] = 0;
     for (ii = 0; ii < 18; ii++)
     {
-        accm = 0;
-        for (jj = 0; jj < 4; jj++)
-        {
-            accm += *chip->channel[ii].out[jj];
-        }
-        chip->mixbuff[0] += (Bit16s)((accm * chip->channel[ii].chl / 65535) & chip->channel[ii].cha);
+        channel = &chip->channel[ii];
+        out = channel->out;
+        accm = *out[0] + *out[1] + *out[2] + *out[3];
+#if OPL_ENABLE_STEREOEXT
+        mix[0] += (int16_t)((accm * channel->leftpan) >> 16);
+#else
+        mix[0] += (int16_t)((accm * chip->channel[ii].chl / 65535) & channel->cha);
+#endif
+        mix[1] += (int16_t)(accm & channel->chc);
     }
+    chip->mixbuff[0] = mix[0];
+    chip->mixbuff[2] = mix[1];
 
+#if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 15; ii < 18; ii++)
     {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_SlotGenerate(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
+#endif
 
-    buf[0] = OPL3_ClipSample(chip->mixbuff[0]);
+    buf4[0] = OPL3_ClipSample(chip->mixbuff[0]);
+    buf4[2] = OPL3_ClipSample(chip->mixbuff[2]);
 
+#if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 18; ii < 33; ii++)
     {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_SlotGenerate(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
+#endif
 
-    chip->mixbuff[1] = 0;
+    mix[0] = mix[1] = 0;
     for (ii = 0; ii < 18; ii++)
     {
-        accm = 0;
-        for (jj = 0; jj < 4; jj++)
-        {
-            accm += *chip->channel[ii].out[jj];
-        }
-        chip->mixbuff[1] += (Bit16s)((accm * chip->channel[ii].chr / 65535) & chip->channel[ii].chb);
+        channel = &chip->channel[ii];
+        out = channel->out;
+        accm = *out[0] + *out[1] + *out[2] + *out[3];
+#if OPL_ENABLE_STEREOEXT
+        mix[0] += (int16_t)((accm * channel->rightpan) >> 16);
+#else
+        mix[0] += (int16_t)((accm * chip->channel[ii].chr / 65535) & channel->chb);
+ #endif
+        mix[1] += (int16_t)(accm & channel->chd);
     }
+    chip->mixbuff[1] = mix[0];
+    chip->mixbuff[3] = mix[1];
 
+#if OPL_QUIRK_CHANNELSAMPLEDELAY
     for (ii = 33; ii < 36; ii++)
     {
-        OPL3_SlotCalcFB(&chip->slot[ii]);
-        OPL3_EnvelopeCalc(&chip->slot[ii]);
-        OPL3_PhaseGenerate(&chip->slot[ii]);
-        OPL3_SlotGenerate(&chip->slot[ii]);
+        OPL3_ProcessSlot(&chip->slot[ii]);
     }
+#endif
 
     if ((chip->timer & 0x3f) == 0x3f)
     {
@@ -1378,7 +1454,7 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 
     if (chip->eg_timerrem || chip->eg_state)
     {
-        if (chip->eg_timer == 0xfffffffffULL)
+        if (chip->eg_timer == UINT64_C(0xfffffffff))
         {
             chip->eg_timer = 0;
             chip->eg_timerrem = 1;
@@ -1392,109 +1468,152 @@ void OPL3_Generate(opl3_chip *chip, Bit16s *buf)
 
     chip->eg_state ^= 1;
 
-    while (chip->writebuf[chip->writebuf_cur].time <= chip->writebuf_samplecnt)
+    while ((writebuf = &chip->writebuf[chip->writebuf_cur]), writebuf->time <= chip->writebuf_samplecnt)
     {
-        if (!(chip->writebuf[chip->writebuf_cur].reg & 0x200))
+        if (!(writebuf->reg & 0x200))
         {
             break;
         }
-        chip->writebuf[chip->writebuf_cur].reg &= 0x1ff;
-        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_cur].reg,
-                      chip->writebuf[chip->writebuf_cur].data);
+        writebuf->reg &= 0x1ff;
+        OPL3_WriteReg(chip, writebuf->reg, writebuf->data);
         chip->writebuf_cur = (chip->writebuf_cur + 1) % OPL_WRITEBUF_SIZE;
     }
     chip->writebuf_samplecnt++;
 }
 
-void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf)
+void OPL3_Generate(opl3_chip *chip, int16_t *buf)
+{
+    int16_t samples[4];
+    OPL3_Generate4Ch(chip, samples);
+    buf[0] = samples[0];
+    buf[1] = samples[1];
+}
+
+void OPL3_Generate4ChResampled(opl3_chip *chip, int16_t *buf4)
 {
     while (chip->samplecnt >= chip->rateratio)
     {
         chip->oldsamples[0] = chip->samples[0];
         chip->oldsamples[1] = chip->samples[1];
-        OPL3_Generate(chip, chip->samples);
+        chip->oldsamples[2] = chip->samples[2];
+        chip->oldsamples[3] = chip->samples[3];
+        OPL3_Generate4Ch(chip, chip->samples);
         chip->samplecnt -= chip->rateratio;
     }
-    buf[0] = (Bit16s)((chip->oldsamples[0] * (chip->rateratio - chip->samplecnt)
-                     + chip->samples[0] * chip->samplecnt) / chip->rateratio);
-    buf[1] = (Bit16s)((chip->oldsamples[1] * (chip->rateratio - chip->samplecnt)
-                     + chip->samples[1] * chip->samplecnt) / chip->rateratio);
+    buf4[0] = (int16_t)((chip->oldsamples[0] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[0] * chip->samplecnt) / chip->rateratio);
+    buf4[1] = (int16_t)((chip->oldsamples[1] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[1] * chip->samplecnt) / chip->rateratio);
+    buf4[2] = (int16_t)((chip->oldsamples[2] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[2] * chip->samplecnt) / chip->rateratio);
+    buf4[3] = (int16_t)((chip->oldsamples[3] * (chip->rateratio - chip->samplecnt)
+                        + chip->samples[3] * chip->samplecnt) / chip->rateratio);
     chip->samplecnt += 1 << RSM_FRAC;
 }
 
-void OPL3_Reset(opl3_chip *chip, Bit32u samplerate)
+void OPL3_GenerateResampled(opl3_chip *chip, int16_t *buf)
 {
-    Bit8u slotnum;
-    Bit8u channum;
+    int16_t samples[4];
+    OPL3_Generate4ChResampled(chip, samples);
+    buf[0] = samples[0];
+    buf[1] = samples[1];
+}
+
+void OPL3_Reset(opl3_chip *chip, uint32_t samplerate)
+{
+    opl3_slot *slot;
+    opl3_channel *channel;
+    uint8_t slotnum;
+    uint8_t channum;
+    uint8_t local_ch_slot;
 
     memset(chip, 0, sizeof(opl3_chip));
     for (slotnum = 0; slotnum < 36; slotnum++)
     {
-        chip->slot[slotnum].chip = chip;
-        chip->slot[slotnum].mod = &chip->zeromod;
-        chip->slot[slotnum].eg_rout = 0x1ff;
+        slot = &chip->slot[slotnum];
+        slot->chip = chip;
+        slot->mod = &chip->zeromod;
+        slot->eg_rout = 0x1ff;
 #if OPL_FAST_WAVEGEN
-        chip->slot[slotnum].eg_out = 0x1ff << 3;
+        slot->eg_out = 0x1ff << 3;
 #else
-        chip->slot[slotnum].eg_out = 0x1ff;
+        slot->eg_out = 0x1ff;
 #endif
-        chip->slot[slotnum].eg_gen = envelope_gen_num_release;
-        chip->slot[slotnum].trem = (Bit8u*)&chip->zeromod;
-        chip->slot[slotnum].slot_num = slotnum;
+        slot->eg_gen = envelope_gen_num_release;
+        slot->trem = (uint8_t*)&chip->zeromod;
+        slot->slot_num = slotnum;
 #if OPL_FAST_WAVEGEN
-        chip->slot[slotnum].signpos = (31-9);  /* for wf=0 need use sigext of (phase & 0x200) */
+        slot->signpos = (31-9);  /* for wf=0 need use sigext of (phase & 0x200) */
 #endif
     }
     for (channum = 0; channum < 18; channum++)
     {
-        chip->channel[channum].slotz[0] = &chip->slot[ch_slot[channum]];
-        chip->channel[channum].slotz[1] = &chip->slot[ch_slot[channum] + 3];
-        chip->slot[ch_slot[channum]].channel = &chip->channel[channum];
-        chip->slot[ch_slot[channum] + 3].channel = &chip->channel[channum];
+        channel = &chip->channel[channum];
+        local_ch_slot = ch_slot[channum];
+        channel->slotz[0] = &chip->slot[local_ch_slot];
+        channel->slotz[1] = &chip->slot[local_ch_slot + 3];
+        chip->slot[local_ch_slot].channel = channel;
+        chip->slot[local_ch_slot + 3].channel = channel;
         if ((channum % 9) < 3)
         {
-            chip->channel[channum].pair = &chip->channel[channum + 3];
+            channel->pair = &chip->channel[channum + 3];
         }
         else if ((channum % 9) < 6)
         {
-            chip->channel[channum].pair = &chip->channel[channum - 3];
+            channel->pair = &chip->channel[channum - 3];
         }
-        chip->channel[channum].chip = chip;
-        chip->channel[channum].out[0] = &chip->zeromod;
-        chip->channel[channum].out[1] = &chip->zeromod;
-        chip->channel[channum].out[2] = &chip->zeromod;
-        chip->channel[channum].out[3] = &chip->zeromod;
-        chip->channel[channum].chtype = ch_2op;
-        chip->channel[channum].cha = 0xffff;
-        chip->channel[channum].chb = 0xffff;
-        chip->channel[channum].chl = 46340;
-        chip->channel[channum].chr = 46340;
-        chip->channel[channum].ch_num = channum;
-        OPL3_ChannelSetupAlg(&chip->channel[channum]);
+        channel->chip = chip;
+        channel->out[0] = &chip->zeromod;
+        channel->out[1] = &chip->zeromod;
+        channel->out[2] = &chip->zeromod;
+        channel->out[3] = &chip->zeromod;
+        channel->chtype = ch_2op;
+        channel->cha = 0xffff;
+        channel->chb = 0xffff;
+        channel->chl = 46340;
+        channel->chr = 46340;
+#if OPL_ENABLE_STEREOEXT
+        channel->leftpan = 0x10000;
+        channel->rightpan = 0x10000;
+#endif
+        channel->ch_num = channum;
+        OPL3_ChannelSetupAlg(channel);
     }
     chip->noise = 1;
     chip->rateratio = (samplerate << RSM_FRAC) / 49716;
     chip->tremoloshift = 4;
     chip->vibshift = 1;
+
+#if OPL_ENABLE_STEREOEXT
+    if (!panpot_lut_build)
+    {
+        int32_t i;
+        for (i = 0; i < 256; i++)
+        {
+            panpot_lut[i] = OPL_SIN(i);
+        }
+        panpot_lut_build = 1;
+    }
+#endif
 }
 
-static void OPL3_ChannelWritePan(opl3_channel *channel, Bit8u data)
+static void OPL3_ChannelWritePan(opl3_channel *channel, uint8_t data)
 {
     channel->chl = panlawtable[data & 0x7F];
     channel->chr = panlawtable[0x7F - (data & 0x7F)];
 }
 
-void OPL3_WritePan(opl3_chip *chip, Bit16u reg, Bit8u v)
+void OPL3_WritePan(opl3_chip *chip, uint16_t reg, uint8_t v)
 {
-    Bit8u high = (reg >> 8) & 0x01;
-    Bit8u regm = reg & 0xff;
+    uint8_t high = (reg >> 8) & 0x01;
+    uint8_t regm = reg & 0xff;
     OPL3_ChannelWritePan(&chip->channel[9 * high + (regm & 0x0f)], v);
 }
 
-void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
+void OPL3_WriteReg(opl3_chip *chip, uint16_t reg, uint8_t v)
 {
-    Bit8u high = (reg >> 8) & 0x01;
-    Bit8u regm = reg & 0xff;
+    uint8_t high = (reg >> 8) & 0x01;
+    uint8_t regm = reg & 0xff;
     switch (regm & 0xf0)
     {
     case 0x00:
@@ -1507,6 +1626,9 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
                 break;
             case 0x05:
                 chip->newm = v & 0x01;
+#if OPL_ENABLE_STEREOEXT
+                chip->stereoext = (v >> 1) & 0x01;
+#endif
                 break;
             }
         }
@@ -1587,24 +1709,36 @@ void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v)
             OPL3_ChannelWriteC0(&chip->channel[9 * high + (regm & 0x0f)], v);
         }
         break;
+#if OPL_ENABLE_STEREOEXT
+    case 0xd0:
+        if ((regm & 0x0f) < 9)
+        {
+            OPL3_ChannelWriteD0(&chip->channel[9 * high + (regm & 0x0f)], v);
+        }
+        break;
+#endif
     }
 }
 
-void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
+void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v)
 {
-    Bit64u time1, time2;
+    uint64_t time1, time2;
+    opl3_writebuf *writebuf;
+    uint32_t writebuf_last;
 
-    if (chip->writebuf[chip->writebuf_last].reg & 0x200)
+    writebuf_last = chip->writebuf_last;
+    writebuf = &chip->writebuf[writebuf_last];
+
+    if (writebuf->reg & 0x200)
     {
-        OPL3_WriteReg(chip, chip->writebuf[chip->writebuf_last].reg & 0x1ff,
-                      chip->writebuf[chip->writebuf_last].data);
+        OPL3_WriteReg(chip, writebuf->reg & 0x1ff, writebuf->data);
 
-        chip->writebuf_cur = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
-        chip->writebuf_samplecnt = chip->writebuf[chip->writebuf_last].time;
+        chip->writebuf_cur = (writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+        chip->writebuf_samplecnt = writebuf->time;
     }
 
-    chip->writebuf[chip->writebuf_last].reg = reg | 0x200;
-    chip->writebuf[chip->writebuf_last].data = v;
+    writebuf->reg = reg | 0x200;
+    writebuf->data = v;
     time1 = chip->writebuf_lasttime + OPL_WRITEBUF_DELAY;
     time2 = chip->writebuf_samplecnt;
 
@@ -1613,39 +1747,35 @@ void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v)
         time1 = time2;
     }
 
-    chip->writebuf[chip->writebuf_last].time = time1;
+    writebuf->time = time1;
     chip->writebuf_lasttime = time1;
-    chip->writebuf_last = (chip->writebuf_last + 1) % OPL_WRITEBUF_SIZE;
+    chip->writebuf_last = (writebuf_last + 1) % OPL_WRITEBUF_SIZE;
 }
 
-void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
+void OPL3_Generate4ChStream(opl3_chip *chip, int16_t *sndptr1, int16_t *sndptr2, uint32_t numsamples)
 {
-    Bit32u i;
+    uint_fast32_t i;
+    int16_t samples[4];
+
+    for(i = 0; i < numsamples; i++)
+    {
+        OPL3_Generate4ChResampled(chip, samples);
+        sndptr1[0] = samples[0];
+        sndptr1[1] = samples[1];
+        sndptr2[0] = samples[2];
+        sndptr2[1] = samples[3];
+        sndptr1 += 2;
+        sndptr2 += 2;
+    }
+}
+
+void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples)
+{
+    uint_fast32_t i;
 
     for(i = 0; i < numsamples; i++)
     {
         OPL3_GenerateResampled(chip, sndptr);
-        sndptr += 2;
-    }
-}
-
-#define OPL3_MIN(A, B)          (((A) > (B)) ? (B) : (A))
-#define OPL3_MAX(A, B)          (((A) < (B)) ? (B) : (A))
-#define OPL3_CLAMP(V, MIN, MAX) OPL3_MAX(OPL3_MIN(V, MAX), MIN)
-
-void OPL3_GenerateStreamMix(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples)
-{
-    Bit32u i;
-    Bit16s sample[2];
-    Bit32s mix[2];
-
-    for(i = 0; i < numsamples; i++)
-    {
-        OPL3_GenerateResampled(chip, sample);
-        mix[0] = sndptr[0] + sample[0];
-        mix[1] = sndptr[1] + sample[1];
-        sndptr[0] = OPL3_CLAMP(mix[0], INT16_MIN, INT16_MAX);
-        sndptr[1] = OPL3_CLAMP(mix[1], INT16_MIN, INT16_MAX);
         sndptr += 2;
     }
 }

--- a/src/chips/nuked/nukedopl3.h
+++ b/src/chips/nuked/nukedopl3.h
@@ -1,20 +1,21 @@
-/*
- * Copyright (C) 2013-2018 Alexey Khokholov (Nuke.YKT)
+/* Nuked OPL3
+ * Copyright (C) 2013-2020 Nuke.YKT
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
+ * This file is part of Nuked OPL3.
  *
- * This library is distributed in the hope that it will be useful,
+ * Nuked OPL3 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * Nuked OPL3 is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
- *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Nuked OPL3. If not, see <https://www.gnu.org/licenses/>.
+
  *  Nuked OPL3 emulator.
  *  Thanks:
  *      MAME Development Team(Jarek Burczynski, Tatsuyuki Satoh):
@@ -32,28 +33,22 @@
 #ifndef OPL_OPL3_H
 #define OPL_OPL3_H
 
-#include <inttypes.h>
-#include <stdint.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+#include <inttypes.h>
+
+#ifndef OPL_ENABLE_STEREOEXT
+#define OPL_ENABLE_STEREOEXT 0
+#endif
+
+#ifndef OPL_FAST_WAVEGEN
+#define OPL_FAST_WAVEGEN 1 /* optimized waveform generation */
+#endif
 
 #define OPL_WRITEBUF_SIZE   1024
 #define OPL_WRITEBUF_DELAY  2
-#define OPL_FAST_WAVEGEN    1 /* optimized waveform generation */
-
-typedef uintptr_t       Bitu;
-typedef intptr_t        Bits;
-typedef uint64_t        Bit64u;
-typedef int64_t         Bit64s;
-typedef uint32_t        Bit32u;
-typedef int32_t         Bit32s;
-typedef uint16_t        Bit16u;
-typedef int16_t         Bit16s;
-typedef uint8_t         Bit8u;
-typedef int8_t          Bit8s;
 
 typedef struct _opl3_slot opl3_slot;
 typedef struct _opl3_channel opl3_channel;
@@ -62,38 +57,38 @@ typedef struct _opl3_chip opl3_chip;
 struct _opl3_slot {
     opl3_channel *channel;
     opl3_chip *chip;
-    Bit16s out;
-    Bit16s fbmod;
-    Bit16s *mod;
-    Bit16s prout;
-    Bit16s eg_rout;
-    Bit16s eg_out;
-    Bit8u eg_inc;
-    Bit8u eg_gen;
-    Bit8u eg_rate;
-    Bit8u eg_ksl;
-    Bit8u *trem;
-    Bit8u reg_vib;
-    Bit8u reg_type;
-    Bit8u reg_ksr;
-    Bit8u reg_mult;
-    Bit8u reg_ksl;
-    Bit8u reg_tl;
-    Bit8u reg_ar;
-    Bit8u reg_dr;
-    Bit8u reg_sl;
-    Bit8u reg_rr;
-    Bit8u reg_wf;
-    Bit8u key;
-    Bit32u pg_reset;
-    Bit32u pg_phase;
-    Bit16u pg_phase_out;
-    Bit8u slot_num;
+    int16_t out;
+    int16_t fbmod;
+    int16_t *mod;
+    int16_t prout;
+    uint16_t eg_rout;
+    uint16_t eg_out;
+    uint8_t eg_inc;
+    uint8_t eg_gen;
+    uint8_t eg_rate;
+    uint8_t eg_ksl;
+    uint8_t *trem;
+    uint8_t reg_vib;
+    uint8_t reg_type;
+    uint8_t reg_ksr;
+    uint8_t reg_mult;
+    uint8_t reg_ksl;
+    uint8_t reg_tl;
+    uint8_t reg_ar;
+    uint8_t reg_dr;
+    uint8_t reg_sl;
+    uint8_t reg_rr;
+    uint8_t reg_wf;
+    uint8_t key;
+    uint32_t pg_reset;
+    uint32_t pg_phase;
+    uint16_t pg_phase_out;
+    uint8_t slot_num;
 
 #if OPL_FAST_WAVEGEN
-    Bit16u maskzero;
-    Bit8u  signpos;
-    Bit8u  phaseshift;
+    uint16_t maskzero;
+    uint8_t  signpos;
+    uint8_t  phaseshift;
 #endif
 };
 
@@ -101,71 +96,86 @@ struct _opl3_channel {
     opl3_slot *slotz[2];/*Don't use "slots" keyword to avoid conflict with Qt applications*/
     opl3_channel *pair;
     opl3_chip *chip;
-    Bit16s *out[4];
-    Bit8u chtype;
-    Bit16u f_num;
-    Bit8u block;
-    Bit8u fb;
-    Bit8u con;
-    Bit8u alg;
-    Bit8u ksv;
-    Bit16u cha, chb;
-    Bit16u chl, chr;
-    Bit8u ch_num;
+    int16_t *out[4];
+
+#if OPL_ENABLE_STEREOEXT
+    int32_t leftpan;
+    int32_t rightpan;
+#endif
+
+    uint8_t chtype;
+    uint16_t f_num;
+    uint8_t block;
+    uint8_t fb;
+    uint8_t con;
+    uint8_t alg;
+    uint8_t ksv;
+    uint16_t cha, chb;
+    uint16_t chc, chd;
+    uint16_t chl, chr;
+    uint8_t ch_num;
 };
 
 typedef struct _opl3_writebuf {
-    Bit64u time;
-    Bit16u reg;
-    Bit8u data;
+    uint64_t time;
+    uint16_t reg;
+    uint8_t data;
 } opl3_writebuf;
 
 struct _opl3_chip {
     opl3_channel channel[18];
     opl3_slot slot[36];
-    Bit16u timer;
-    Bit64u eg_timer;
-    Bit8u eg_timerrem;
-    Bit8u eg_state;
-    Bit8u eg_add;
-    Bit8u newm;
-    Bit8u nts;
-    Bit8u rhy;
-    Bit8u vibpos;
-    Bit8u vibshift;
-    Bit8u tremolo;
-    Bit8u tremolopos;
-    Bit8u tremoloshift;
-    Bit32u noise;
-    Bit16s zeromod;
-    Bit32s mixbuff[2];
-    Bit8u rm_hh_bit2;
-    Bit8u rm_hh_bit3;
-    Bit8u rm_hh_bit7;
-    Bit8u rm_hh_bit8;
-    Bit8u rm_tc_bit3;
-    Bit8u rm_tc_bit5;
-    /* OPL3L */
-    Bit32s rateratio;
-    Bit32s samplecnt;
-    Bit16s oldsamples[2];
-    Bit16s samples[2];
+    uint16_t timer;
+    uint64_t eg_timer;
+    uint8_t eg_timerrem;
+    uint8_t eg_state;
+    uint8_t eg_add;
+    uint8_t newm;
+    uint8_t nts;
+    uint8_t rhy;
+    uint8_t vibpos;
+    uint8_t vibshift;
+    uint8_t tremolo;
+    uint8_t tremolopos;
+    uint8_t tremoloshift;
+    uint32_t noise;
+    int16_t zeromod;
+    int32_t mixbuff[4];
+    uint8_t rm_hh_bit2;
+    uint8_t rm_hh_bit3;
+    uint8_t rm_hh_bit7;
+    uint8_t rm_hh_bit8;
+    uint8_t rm_tc_bit3;
+    uint8_t rm_tc_bit5;
 
-    Bit64u writebuf_samplecnt;
-    Bit32u writebuf_cur;
-    Bit32u writebuf_last;
-    Bit64u writebuf_lasttime;
+#if OPL_ENABLE_STEREOEXT
+    uint8_t stereoext;
+#endif
+
+    /* OPL3L */
+    int32_t rateratio;
+    int32_t samplecnt;
+    int16_t oldsamples[4];
+    int16_t samples[4];
+
+    uint64_t writebuf_samplecnt;
+    uint32_t writebuf_cur;
+    uint32_t writebuf_last;
+    uint64_t writebuf_lasttime;
     opl3_writebuf writebuf[OPL_WRITEBUF_SIZE];
 };
 
-void OPL3_Generate(opl3_chip *chip, Bit16s *buf);
-void OPL3_GenerateResampled(opl3_chip *chip, Bit16s *buf);
-void OPL3_Reset(opl3_chip *chip, Bit32u samplerate);
-void OPL3_WriteReg(opl3_chip *chip, Bit16u reg, Bit8u v);
-void OPL3_WriteRegBuffered(opl3_chip *chip, Bit16u reg, Bit8u v);
-void OPL3_WritePan(opl3_chip *chip, Bit16u reg, Bit8u v);
-void OPL3_GenerateStream(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
-void OPL3_GenerateStreamMix(opl3_chip *chip, Bit16s *sndptr, Bit32u numsamples);
+void OPL3_Generate(opl3_chip *chip, int16_t *buf);
+void OPL3_GenerateResampled(opl3_chip *chip, int16_t *buf);
+void OPL3_Reset(opl3_chip *chip, uint32_t samplerate);
+void OPL3_WriteReg(opl3_chip *chip, uint16_t reg, uint8_t v);
+void OPL3_WriteRegBuffered(opl3_chip *chip, uint16_t reg, uint8_t v);
+void OPL3_WritePan(opl3_chip *chip, uint16_t reg, uint8_t v);
+void OPL3_GenerateStream(opl3_chip *chip, int16_t *sndptr, uint32_t numsamples);
+
+void OPL3_Generate4Ch(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChResampled(opl3_chip *chip, int16_t *buf4);
+void OPL3_Generate4ChStream(opl3_chip *chip, int16_t *sndptr1, int16_t *sndptr2, uint32_t numsamples);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I took the latest Nuked OPL 1.8 code from https://github.com/nukeykt/Nuked-OPL3 and applied changes from libADLMIDI.

It's faster than the old Nuked OPL 1.8 code in libADLMIDI.
The 32-bit version (x86) was faster than Nuked OPL 1.7 version in my testing.
The 64-bit version (x64) was slower than Nuked OPL 1.7 version.