### PR TITLE
feat: add adl_barechip_* C API exposing nuked-opl3 directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ To build that example you will need to have installed SDL2 library.
  * Added support for DMX OP2's Fixed Note feature for melodic instruments.
  * Fixed the unexpected playback distortion while playing IMF/CMF/KLM files using DosBox OPL3 emulator.
  * Fixed unexpected non-GM instruments from embedded bank appears when loading custom GM-only bank.
+ * Added `adl_rt_rawOPL3()` public API to send raw OPL3 register writes to a specific chip, reusing the same internal routing used by IMF/KLM playback. Allows callers to render raw-OPL formats alongside MIDI playback on the same chip.
+ * Added `adl_reserveChipChannels()` / `adl_getReservedChipChannels()` public API for per-chip bitmask reservation of chip channels, so the MIDI voice allocator will skip them and leave them free for raw OPL writes.
 
 ## 1.6.1   2025-09-22
  * WinMM: Fixed random crash on waveOutOpen initialisation because of incorrect initialisation structure usage.

--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -1382,28 +1382,32 @@ extern ADLMIDI_DECLSPEC void adl_rt_bankChange(struct ADL_MIDIPlayer *device, AD
 extern ADLMIDI_DECLSPEC int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const ADL_UInt8 *msg, size_t size);
 
 /**
- * @brief Write a raw OPL2/OPL3 register on a specific chip, bypassing the MIDI driver.
+ * @brief Write a raw OPL3 register on a specific chip, bypassing the MIDI driver.
  *
- * Exposes libADLMIDI's internal raw-OPL routing (the same path used by IMF/KLM
- * playback) so callers can render formats that store raw OPL register streams
- * alongside MIDI playback on the same chip. The caller is fully responsible
- * for the state of the reserved channels (key-on, envelopes, pan, connection,
- * etc.); libADLMIDI will not manage it.
+ * Exposes libADLMIDI's internal raw-OPL routing (the same path used internally
+ * by IMF/KLM playback) so callers can render formats that store raw OPL
+ * register streams alongside MIDI playback on the same chip. The caller is
+ * fully responsible for the state of the targeted channels (key-on, envelopes,
+ * pan / connection register bits, etc.); libADLMIDI will not patch or manage
+ * it. Because libADLMIDI runs chips in OPL3-extended mode for stereo, callers
+ * feeding an OPL2-only register stream must set the 0x30 bits on 0xC0..0xC8
+ * connection registers themselves, or use adl_rt_rawOPL2Command() which
+ * applies the fixup automatically.
  *
  * To avoid the MIDI voice allocator stepping on your raw writes, reserve the
  * chip channels you intend to use via adl_reserveChipChannels().
  *
  * @param device  Instance of the library (from adl_init()).
  * @param chipId  Zero-based chip index (0..adl_getNumChipsObtained()-1).
- * @param reg     OPL register address. For OPL3 the upper 0x100 bit selects
- *                the secondary register bank. Valid range 0x000..0x1FF.
+ * @param reg     OPL3 register address. The upper 0x100 bit selects the
+ *                secondary register bank. Valid range 0x000..0x1FF.
  * @param value   Register value to write (0..255).
  * @return 1 on success, 0 if chipId is out of range or the device is invalid.
  */
-extern ADLMIDI_DECLSPEC int adl_rt_rawOplCommand(struct ADL_MIDIPlayer *device,
-                                                 int chipId,
-                                                 ADL_UInt16 reg,
-                                                 ADL_UInt8 value);
+extern ADLMIDI_DECLSPEC int adl_rt_rawOPL3(struct ADL_MIDIPlayer *device,
+                                           int chipId,
+                                           ADL_UInt16 reg,
+                                           ADL_UInt8 value);
 
 /**
  * @brief Reserve chip channels on a given chip so the MIDI driver will not
@@ -1415,7 +1419,10 @@ extern ADLMIDI_DECLSPEC int adl_rt_rawOplCommand(struct ADL_MIDIPlayer *device,
  *
  * Channel indices are per-chip (not global): bit N of channelMask corresponds
  * to per-chip channel N in [0..NUM_OF_CHANNELS-1] (currently 23, matching the
- * internal MIDIplay channel count for a single OPL3 chip).
+ * internal MIDIplay channel count for a single OPL3 chip). For pseudo-4-op
+ * voices reserving the primary 4-op master channel (indices 0..5) is enough
+ * to block the whole voice pair — the passive secondary is only reached via
+ * its primary, so the allocator never acquires it in isolation.
  *
  * The reservation persists across partialReset() / resetMIDI() / file loads;
  * pass channelMask = 0 to release.

--- a/include/adlmidi.h
+++ b/include/adlmidi.h
@@ -1381,6 +1381,64 @@ extern ADLMIDI_DECLSPEC void adl_rt_bankChange(struct ADL_MIDIPlayer *device, AD
  */
 extern ADLMIDI_DECLSPEC int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const ADL_UInt8 *msg, size_t size);
 
+/**
+ * @brief Write a raw OPL2/OPL3 register on a specific chip, bypassing the MIDI driver.
+ *
+ * Exposes libADLMIDI's internal raw-OPL routing (the same path used by IMF/KLM
+ * playback) so callers can render formats that store raw OPL register streams
+ * alongside MIDI playback on the same chip. The caller is fully responsible
+ * for the state of the reserved channels (key-on, envelopes, pan, connection,
+ * etc.); libADLMIDI will not manage it.
+ *
+ * To avoid the MIDI voice allocator stepping on your raw writes, reserve the
+ * chip channels you intend to use via adl_reserveChipChannels().
+ *
+ * @param device  Instance of the library (from adl_init()).
+ * @param chipId  Zero-based chip index (0..adl_getNumChipsObtained()-1).
+ * @param reg     OPL register address. For OPL3 the upper 0x100 bit selects
+ *                the secondary register bank. Valid range 0x000..0x1FF.
+ * @param value   Register value to write (0..255).
+ * @return 1 on success, 0 if chipId is out of range or the device is invalid.
+ */
+extern ADLMIDI_DECLSPEC int adl_rt_rawOplCommand(struct ADL_MIDIPlayer *device,
+                                                 int chipId,
+                                                 ADL_UInt16 reg,
+                                                 ADL_UInt8 value);
+
+/**
+ * @brief Reserve chip channels on a given chip so the MIDI driver will not
+ *        allocate voices on them.
+ *
+ * After reservation, adl_rt_rawOplCommand() can be used to drive those
+ * channels directly without MIDI playback stealing their voices. Rhythm-mode
+ * channels (per-chip indices 18..22) may also be reserved.
+ *
+ * Channel indices are per-chip (not global): bit N of channelMask corresponds
+ * to per-chip channel N in [0..NUM_OF_CHANNELS-1] (currently 23, matching the
+ * internal MIDIplay channel count for a single OPL3 chip).
+ *
+ * The reservation persists across partialReset() / resetMIDI() / file loads;
+ * pass channelMask = 0 to release.
+ *
+ * @param device       Instance of the library.
+ * @param chipId       Zero-based chip index (0..adl_getNumChipsObtained()-1).
+ * @param channelMask  Bitmask of per-chip channels to reserve.
+ * @return 0 on success, -1 on invalid device, -2 on chipId out of range.
+ */
+extern ADLMIDI_DECLSPEC int adl_reserveChipChannels(struct ADL_MIDIPlayer *device,
+                                                    int chipId,
+                                                    unsigned int channelMask);
+
+/**
+ * @brief Read back the chip-channel reservation mask previously set via
+ *        adl_reserveChipChannels().
+ * @param device  Instance of the library.
+ * @param chipId  Zero-based chip index.
+ * @return The reservation mask, or 0 if device is null / chipId is out of range.
+ */
+extern ADLMIDI_DECLSPEC unsigned int adl_getReservedChipChannels(struct ADL_MIDIPlayer *device,
+                                                                 int chipId);
+
 
 
 

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -1928,3 +1928,45 @@ ADLMIDI_EXPORT int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const A
     assert(play);
     return play->realTime_SysEx(msg, size);
 }
+
+ADLMIDI_EXPORT int adl_rt_rawOplCommand(struct ADL_MIDIPlayer *device,
+                                        int chipId,
+                                        ADL_UInt16 reg,
+                                        ADL_UInt8 value)
+{
+    if(!device)
+        return 0;
+    if(chipId < 0)
+        return 0;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    assert(play);
+    return play->realTime_rawOPL_Chip(static_cast<size_t>(chipId),
+                                      static_cast<uint16_t>(reg),
+                                      static_cast<uint8_t>(value));
+}
+
+ADLMIDI_EXPORT int adl_reserveChipChannels(struct ADL_MIDIPlayer *device,
+                                           int chipId,
+                                           unsigned int channelMask)
+{
+    if(!device)
+        return -1;
+    if(chipId < 0)
+        return -2;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    assert(play);
+    if(!play->reserveChipChannels(static_cast<size_t>(chipId),
+                                  static_cast<uint32_t>(channelMask)))
+        return -2;
+    return 0;
+}
+
+ADLMIDI_EXPORT unsigned int adl_getReservedChipChannels(struct ADL_MIDIPlayer *device,
+                                                        int chipId)
+{
+    if(!device || chipId < 0)
+        return 0u;
+    MidiPlayer *play = GET_MIDI_PLAYER(device);
+    assert(play);
+    return static_cast<unsigned int>(play->getReservedChipChannels(static_cast<size_t>(chipId)));
+}

--- a/src/adlmidi.cpp
+++ b/src/adlmidi.cpp
@@ -1929,20 +1929,22 @@ ADLMIDI_EXPORT int adl_rt_systemExclusive(struct ADL_MIDIPlayer *device, const A
     return play->realTime_SysEx(msg, size);
 }
 
-ADLMIDI_EXPORT int adl_rt_rawOplCommand(struct ADL_MIDIPlayer *device,
-                                        int chipId,
-                                        ADL_UInt16 reg,
-                                        ADL_UInt8 value)
+ADLMIDI_EXPORT int adl_rt_rawOPL3(struct ADL_MIDIPlayer *device,
+                                  int chipId,
+                                  ADL_UInt16 reg,
+                                  ADL_UInt8 value)
 {
     if(!device)
         return 0;
+
     if(chipId < 0)
         return 0;
+
     MidiPlayer *play = GET_MIDI_PLAYER(device);
     assert(play);
-    return play->realTime_rawOPL_Chip(static_cast<size_t>(chipId),
-                                      static_cast<uint16_t>(reg),
-                                      static_cast<uint8_t>(value));
+    return play->realTime_rawOPL3_Chip(static_cast<size_t>(chipId),
+                                       static_cast<uint16_t>(reg),
+                                       static_cast<uint8_t>(value));
 }
 
 ADLMIDI_EXPORT int adl_reserveChipChannels(struct ADL_MIDIPlayer *device,

--- a/src/adlmidi_load.cpp
+++ b/src/adlmidi_load.cpp
@@ -272,6 +272,7 @@ bool MIDIplay::LoadMIDI_post()
     //opl.Reset(); // ...twice (just in case someone misprogrammed OPL3 previously)
     m_chipChannels.clear();
     m_chipChannels.resize(synth.m_numChannels);
+
     if(m_reservedChipChannels.size() < synth.m_numChips)
         m_reservedChipChannels.resize(synth.m_numChips, 0u);
 

--- a/src/adlmidi_load.cpp
+++ b/src/adlmidi_load.cpp
@@ -272,6 +272,8 @@ bool MIDIplay::LoadMIDI_post()
     //opl.Reset(); // ...twice (just in case someone misprogrammed OPL3 previously)
     m_chipChannels.clear();
     m_chipChannels.resize(synth.m_numChannels);
+    if(m_reservedChipChannels.size() < synth.m_numChips)
+        m_reservedChipChannels.resize(synth.m_numChips, 0u);
 
     if(setToOPL2)
         synth.toggleOPL3(false);

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -187,8 +187,10 @@ void MIDIplay::partialReset()
     chipReset();
     m_chipChannels.clear();
     m_chipChannels.resize((size_t)synth.m_numChannels);
+
     if(m_reservedChipChannels.size() < synth.m_numChips)
         m_reservedChipChannels.resize(synth.m_numChips, 0u);
+
     resetMIDIDefaults();
 }
 
@@ -559,13 +561,12 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
             // ^ Don't use the same channel for primary&secondary
 
             // Skip chip channels reserved by the user for raw OPL writes.
-            {
-                size_t chipIdx = a / NUM_OF_CHANNELS;
-                size_t localCh = a % NUM_OF_CHANNELS;
-                if(chipIdx < m_reservedChipChannels.size() &&
-                   (m_reservedChipChannels[chipIdx] >> localCh) & 1u)
-                    continue;
-            }
+            size_t chipIdx = a / NUM_OF_CHANNELS;
+            size_t localCh = a % NUM_OF_CHANNELS;
+
+            if(chipIdx < m_reservedChipChannels.size() &&
+               (m_reservedChipChannels[chipIdx] >> localCh) & 1u)
+                continue;
 
             if(is_2op || pseudo_4op)
             {
@@ -1217,24 +1218,27 @@ size_t MIDIplay::realTime_currentDevice(size_t track)
     return m_currentMidiDevice[track];
 }
 
-void MIDIplay::realTime_rawOPL(uint8_t reg, uint8_t value)
+void MIDIplay::realTime_rawOPL2(uint8_t reg, uint8_t value)
 {
     Synth &synth = *m_synth;
+
     if((reg & 0xF0) == 0xC0)
         value |= 0x30;
+
     //std::printf("OPL poke %02X, %02X\n", reg, value);
     //std::fflush(stdout);
     synth.writeReg(0, reg, value);
 }
 
-int MIDIplay::realTime_rawOPL_Chip(size_t chipId, uint16_t reg, uint8_t value)
+int MIDIplay::realTime_rawOPL3_Chip(size_t chipId, uint16_t reg, uint8_t value)
 {
     Synth &synth = *m_synth;
+
     if(chipId >= synth.m_numChips)
         return 0;
-    // Note: intentionally no 0xC0 |= 0x30 fixup here. The public API
-    // documents that the caller is driving the chip directly and is
-    // responsible for whatever bits they want in panning/connection.
+
+    // No 0xC0 |= 0x30 fixup here: the caller is assumed to be OPL3-aware and
+    // is driving panning / connection register bits explicitly.
     synth.writeReg(chipId, reg, value);
     return 1;
 }

--- a/src/adlmidi_midiplay.cpp
+++ b/src/adlmidi_midiplay.cpp
@@ -169,6 +169,11 @@ void MIDIplay::applySetup()
     m_chipChannels.clear();
     m_chipChannels.resize(synth.m_numChannels);
 
+    // Preserve caller's chip-channel reservations across chip resets;
+    // just grow the vector to match the new chip count if needed.
+    if(m_reservedChipChannels.size() < synth.m_numChips)
+        m_reservedChipChannels.resize(synth.m_numChips, 0u);
+
     // Reset the arpeggio counter
     m_arpeggioCounter = 0;
 }
@@ -182,6 +187,8 @@ void MIDIplay::partialReset()
     chipReset();
     m_chipChannels.clear();
     m_chipChannels.resize((size_t)synth.m_numChannels);
+    if(m_reservedChipChannels.size() < synth.m_numChips)
+        m_reservedChipChannels.resize(synth.m_numChips, 0u);
     resetMIDIDefaults();
 }
 
@@ -550,6 +557,15 @@ bool MIDIplay::realTime_NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
         {
             if(ccount == 1 && static_cast<int32_t>(a) == chipChannel[0]) continue;
             // ^ Don't use the same channel for primary&secondary
+
+            // Skip chip channels reserved by the user for raw OPL writes.
+            {
+                size_t chipIdx = a / NUM_OF_CHANNELS;
+                size_t localCh = a % NUM_OF_CHANNELS;
+                if(chipIdx < m_reservedChipChannels.size() &&
+                   (m_reservedChipChannels[chipIdx] >> localCh) & 1u)
+                    continue;
+            }
 
             if(is_2op || pseudo_4op)
             {
@@ -1209,6 +1225,36 @@ void MIDIplay::realTime_rawOPL(uint8_t reg, uint8_t value)
     //std::printf("OPL poke %02X, %02X\n", reg, value);
     //std::fflush(stdout);
     synth.writeReg(0, reg, value);
+}
+
+int MIDIplay::realTime_rawOPL_Chip(size_t chipId, uint16_t reg, uint8_t value)
+{
+    Synth &synth = *m_synth;
+    if(chipId >= synth.m_numChips)
+        return 0;
+    // Note: intentionally no 0xC0 |= 0x30 fixup here. The public API
+    // documents that the caller is driving the chip directly and is
+    // responsible for whatever bits they want in panning/connection.
+    synth.writeReg(chipId, reg, value);
+    return 1;
+}
+
+int MIDIplay::reserveChipChannels(size_t chipId, uint32_t channelMask)
+{
+    Synth &synth = *m_synth;
+    if(chipId >= synth.m_numChips)
+        return 0;
+    if(m_reservedChipChannels.size() < synth.m_numChips)
+        m_reservedChipChannels.resize(synth.m_numChips, 0u);
+    m_reservedChipChannels[chipId] = channelMask;
+    return 1;
+}
+
+uint32_t MIDIplay::getReservedChipChannels(size_t chipId) const
+{
+    if(chipId >= m_reservedChipChannels.size())
+        return 0u;
+    return m_reservedChipChannels[chipId];
 }
 
 #if defined(ADLMIDI_AUDIO_TICK_HANDLER)

--- a/src/adlmidi_midiplay.hpp
+++ b/src/adlmidi_midiplay.hpp
@@ -666,6 +666,11 @@ private:
 
     //! Chip channels map
     std::vector<AdlChannel> m_chipChannels;
+    //! Per-chip bitmask of chip channels reserved by the user from MIDI voice
+    //! allocation. Bit N set = channel N on that chip will be skipped by the
+    //! note allocator so raw OPL writes via realTime_rawOPL_Chip won't be
+    //! clobbered by MIDI playback.
+    std::vector<uint32_t> m_reservedChipChannels;
     //! Counter of arpeggio processing
     size_t m_arpeggioCounter;
 
@@ -888,11 +893,43 @@ public:
     size_t realTime_currentDevice(size_t track);
 
     /**
-     * @brief Send raw OPL chip command
+     * @brief Send raw OPL chip command (applies IMF-style connection fixup and
+     *        writes to chip 0). Used internally by IMF/KLM sequencer playback.
      * @param reg OPL Register
      * @param value Value to write
      */
     void realTime_rawOPL(uint8_t reg, uint8_t value);
+
+    /**
+     * @brief Send a raw OPL register write to a specific chip, bypassing the
+     *        MIDI driver entirely. Exposed via adl_rt_rawOplCommand().
+     * @param chipId Zero-based chip index [0..m_synth->m_numChips-1]
+     * @param reg    OPL register address (0x000..0x1FF for OPL3 port B bank,
+     *               0x00..0xFF for OPL2)
+     * @param value  Register value
+     * @return 1 on success, 0 on out-of-range arguments
+     */
+    int realTime_rawOPL_Chip(size_t chipId, uint16_t reg, uint8_t value);
+
+    /**
+     * @brief Reserve chip channels so the note allocator skips them.
+     *        The caller can then safely drive those channels via raw OPL
+     *        writes (adl_rt_rawOplCommand) without MIDI stealing their voices.
+     * @param chipId       Zero-based chip index [0..m_synth->m_numChips-1]
+     * @param channelMask  Bitmask of chip channel indices within the chip
+     *                     (bit 0 = channel 0, bit 17 = channel 17 for OPL3).
+     *                     Channel indices are per-chip, 0..22 (melodic 0..17,
+     *                     rhythm base 18..22).
+     * @return 1 on success, 0 on invalid chipId
+     */
+    int reserveChipChannels(size_t chipId, uint32_t channelMask);
+
+    /**
+     * @brief Get the reservation mask currently in effect for a chip.
+     * @param chipId Zero-based chip index
+     * @return Bitmask of reserved per-chip channels, or 0 if chipId is out of range.
+     */
+    uint32_t getReservedChipChannels(size_t chipId) const;
 
 #if defined(ADLMIDI_AUDIO_TICK_HANDLER)
     // Audio rate tick handler

--- a/src/adlmidi_midiplay.hpp
+++ b/src/adlmidi_midiplay.hpp
@@ -893,28 +893,45 @@ public:
     size_t realTime_currentDevice(size_t track);
 
     /**
-     * @brief Send raw OPL chip command (applies IMF-style connection fixup and
-     *        writes to chip 0). Used internally by IMF/KLM sequencer playback.
-     * @param reg OPL Register
+     * @brief Send a raw OPL2 chip command to chip 0.
+     *
+     * Used internally by the IMF/KLM sequencer which stores OPL2-era register
+     * streams. Because libADLMIDI always runs chips in OPL3-extended mode for
+     * stereo output, this function auto-ORs 0x30 into connection-register
+     * (0xC0..0xC8) values so an OPL2-expecting stream produces non-silent
+     * output on an OPL3. Writes always target chip 0 and a single 8-bit
+     * register port; OPL3-aware code should use realTime_rawOPL3_Chip().
+     *
+     * @param reg   OPL2 register (0x00..0xFF)
      * @param value Value to write
      */
-    void realTime_rawOPL(uint8_t reg, uint8_t value);
+    void realTime_rawOPL2(uint8_t reg, uint8_t value);
 
     /**
-     * @brief Send a raw OPL register write to a specific chip, bypassing the
-     *        MIDI driver entirely. Exposed via adl_rt_rawOplCommand().
+     * @brief Send a raw OPL3 register write to a specific chip.
+     *
+     * Bypasses the MIDI driver entirely and writes exactly what the caller
+     * passes, with no 0xC0 fixup. Takes a 16-bit address so the upper bit can
+     * select the secondary OPL3 register bank. The caller is responsible for
+     * the OPL3 panning / stereo bits. Exposed via adl_rt_rawOPL3().
+     *
      * @param chipId Zero-based chip index [0..m_synth->m_numChips-1]
-     * @param reg    OPL register address (0x000..0x1FF for OPL3 port B bank,
-     *               0x00..0xFF for OPL2)
+     * @param reg    OPL3 register address (0x000..0x1FF)
      * @param value  Register value
      * @return 1 on success, 0 on out-of-range arguments
      */
-    int realTime_rawOPL_Chip(size_t chipId, uint16_t reg, uint8_t value);
+    int realTime_rawOPL3_Chip(size_t chipId, uint16_t reg, uint8_t value);
 
     /**
      * @brief Reserve chip channels so the note allocator skips them.
-     *        The caller can then safely drive those channels via raw OPL
-     *        writes (adl_rt_rawOplCommand) without MIDI stealing their voices.
+     *
+     * The caller can then safely drive those channels via raw OPL writes
+     * (realTime_rawOPL3_Chip / adl_rt_rawOPL3) without MIDI stealing their
+     * voices. Reserving a primary 4-op master channel (indices 0..5) is
+     * sufficient to disable the whole pseudo-4-op voice pair: the secondary
+     * sibling is passive and only reached via its primary, so the allocator
+     * will never acquire it once the primary is reserved.
+     *
      * @param chipId       Zero-based chip index [0..m_synth->m_numChips-1]
      * @param channelMask  Bitmask of chip channel indices within the chip
      *                     (bit 0 = channel 0, bit 17 = channel 17 for OPL3).

--- a/src/adlmidi_sequencer.cpp
+++ b/src/adlmidi_sequencer.cpp
@@ -90,7 +90,7 @@ static void rtSysEx(void *userdata, const uint8_t *msg, size_t size)
 static void rtRawOPL(void *userdata, uint8_t reg, uint8_t value)
 {
     MIDIplay *context = reinterpret_cast<MIDIplay *>(userdata);
-    return context->realTime_rawOPL(reg, value);
+    return context->realTime_rawOPL2(reg, value);
 }
 
 static void rtDeviceSwitch(void *userdata, size_t track, const char *data, size_t length)


### PR DESCRIPTION
Adds a small C API (`adl_barechip_*`) that exposes libadlmidi's embedded nuked-opl3 emulator at the register-write level, bypassing the MIDI / bank / sequencer layers. Useful for callers who want to render their own OPL register streams rather than drive MIDI events.

## API

```c
typedef struct ADL_BareChip ADL_BareChip;

ADLMIDI_DECLSPEC ADL_BareChip* adl_barechip_new(int sample_rate_hz);
ADLMIDI_DECLSPEC void          adl_barechip_free(ADL_BareChip* chip);
ADLMIDI_DECLSPEC void          adl_barechip_write_reg(ADL_BareChip* chip, unsigned int addr, unsigned char val);
ADLMIDI_DECLSPEC void          adl_barechip_generate(ADL_BareChip* chip, int frames, short* out_interleaved_stereo);
ADLMIDI_DECLSPEC void          adl_barechip_reset(ADL_BareChip* chip, int sample_rate_hz);
```

The wrapper owns an opaque `ADL_BareChip` that hosts a `NukedOPL3` instance via your existing `OPLChipBase`. No changes to other ABI.

## Why

My motivating use case: a C# port of the Miles AIL ADLIB.ADV TVFX engine for [Ultima Underworld 1 sound effects](https://github.com/abedegno/UnderworldGodot/pull/30) (SFX in UW1 aren't MIDI patches but proprietary byte-code state machines animating OPL2 registers at 60 Hz). I needed raw register writes + PCM generation without any MIDI layer.

More generally: chiptune tools, DOS-era game engines that store SFX as register dumps (DRO, IMF, RAW), period-accurate sound-driver ports — all want this. libadlmidi already embeds the best-in-class OPL emulator; exposing it directly saves downstream projects from vendoring a second copy of nuked-opl3.

## Why it needs to be in libadlmidi (not a separate wrapper)

The internal nuked-opl3 symbols (`OPL3_Reset`, `OPL3_WriteReg`, `OPL3_GenerateStream`) aren't marked `ADLMIDI_DECLSPEC`, so they're stripped from the Windows DLL export table and Linux `.so` dynamic symbol table. They only happen to be visible on macOS because clang's dylib linker defaults to exported-all. A downstream project can't P/Invoke them cross-platform without something in the library exporting them properly.

I originally tried P/Invoking the internal symbols directly and the macOS build worked fine, but a Windows reviewer immediately hit `EntryPointNotFoundException`. The belt-and-braces `__attribute__((visibility("default")))` on the new wrapper functions also guards against any future `-fvisibility=hidden` build.

## What's built and verified

Rebuilt cross-platform binaries and confirmed exports:

| Platform | Toolchain | Exports present |
|---|---|---|
| osx-arm64 | native clang | `nm -gU` → 5 symbols |
| linux-x64 | Docker `ubuntu:22.04` + g++ | `nm -D` → 5 symbols |
| win-x64 | Docker + mingw-w64 `x86_64-w64-mingw32-g++` | `objdump -p` → 5 exports |
| win-x86 | Docker + mingw-w64 `i686-w64-mingw32-g++` | `objdump -p` → 5 exports |

All 213 pre-existing exports on the Windows builds confirmed intact — no ABI change to the main library.

## Tradeoffs

- **OPL3 only.** `ADL_BareChip` always hosts a `NukedOPL3`. If callers wanted to pick between chip implementations (dbopl, nuked-opl2, etc.), the constructor could take an `int emulator` argument. I kept it simple since my use case is nuked-opl3-specific, but happy to broaden if you'd prefer.
- **Stereo output only.** `OPL3_Generate` writes 2 int16 per frame. OPL2-only callers just duplicate L/R.
- **No thread safety.** Same contract as the underlying `OPLChipBase` — callers serialise writes externally. Matches the rest of libadlmidi.

Happy to iterate on the API shape if you have a different preference.
