### PR TITLE
Fix for a wrong bank path in banks.ini, and a duplicated source entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,6 @@ function(handle_options targetLib)
             target_sources(${targetLib} PRIVATE
                 ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox_opl2.cpp
                 ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox_opl2.h
-                ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox_opl2.cpp
                 ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox_opl3.h
                 ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox_opl3.cpp
                 ${libADLMIDI_SOURCE_DIR}/src/chips/dosbox/dbopl.h

--- a/banks.ini
+++ b/banks.ini
@@ -417,7 +417,7 @@ games    = "Caesar 2"
 ;format   = AIL
 ;file     = "fm_banks/ail/miss-inst/Caesar2.opl"
 format   = WOPLX
-file     = "fm_banks_new/ail2/ail-caesar2.woplx"
+file     = "fm_banks_new/ail/ail-caesar2.woplx"
 prefix   = "f12G"
 
 [bank-41]


### PR DESCRIPTION
Two unrelated one-line fixes, spotted while auditing the tree for a vcpkg package. Kept as separate commits.

### `banks.ini` points at a directory that does not exist

Line 420 lists `fm_banks_new/ail2/ail-caesar2.woplx`, but there is no `ail2` directory. The file is at `fm_banks_new/ail/ail-caesar2.woplx` - which is also where `banks-no-grey.ini:329` points for the same bank, with the same `prefix = "f12G"`.

This breaks the build with `-DWITH_GENADLDATA=ON`:

```
Loading bank: 040 = AIL (Caesar 2) :p4op: :MISS-INS:...
WOPLX: CAN'T OPEN FILE .../fm_banks_new/ail2/ail-caesar2.woplx
Failed to load bank 40, file .../fm_banks_new/ail2/ail-caesar2.woplx!
```

Default builds are unaffected, since they use the committed `src/inst_db.cpp`. With the path corrected, `gen_adldata` runs to completion and bank 40 loads. I checked the rest of both lists while I was there: all 79 entries in `banks.ini` and all 79 in `banks-no-grey.ini` now resolve.

### Duplicated source entry

`CMakeLists.txt` lists `src/chips/dosbox_opl2.cpp` twice in the DosBox emulator's `target_sources()`. Harmless to the build, but with the duplicate gone the list reads as the `.cpp` and `.h` of both OPL2 and OPL3 plus the shared `dbopl` core.
